### PR TITLE
adding Graphics wrappers to ignore clearRect calls ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.lwjglx</groupId>
 	<artifactId>lwjgl3-awt</artifactId>
-	<version>0.1.4</version>
+	<version>0.1.5-SNAPSHOT</version>
 	<name>LWJGLX/lwjgl3-awt</name>
 	<description>LWJGLX/lwjgl3-awt</description>
 	<inceptionYear>2016</inceptionYear>

--- a/src/org/lwjgl/awthacks/NonClearGraphics.java
+++ b/src/org/lwjgl/awthacks/NonClearGraphics.java
@@ -1,0 +1,238 @@
+package org.lwjgl.awthacks;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.image.ImageObserver;
+import java.text.AttributedCharacterIterator;
+
+/**
+ * Wrapper for a {@link Graphics} object that delegates to it.
+ * Only {@link NonClearGraphics#clearRect(int, int, int, int)} does
+ * not delegate in order to prevent clearing the Canvas after
+ * it was rendered.
+ * 
+ * @author hageldave
+ * @see NonClearGraphics2D
+ */
+public class NonClearGraphics extends Graphics {
+
+	protected Graphics delegate;
+	
+	public NonClearGraphics(Graphics delegate) {
+		this.delegate = delegate;
+	}
+
+	/**
+	 * Does nothing. This is to prevent a clearRect call from 
+	 * clearing the already rendered Canvas.
+	 */
+	public void clearRect(int x, int y, int width, int height) {
+		// NOOP
+	}
+
+	@Deprecated
+	public Rectangle getClipRect() {
+		return delegate.getClipRect();
+	}
+
+	public NonClearGraphics create() {
+		return new NonClearGraphics(delegate.create());
+	}
+
+	public NonClearGraphics create(int x, int y, int width, int height) {
+		return new NonClearGraphics(delegate.create(x, y, width, height));
+	}
+
+	public void translate(int x, int y) {
+		delegate.translate(x, y);
+	}
+
+	public Color getColor() {
+		return delegate.getColor();
+	}
+
+	public void setColor(Color c) {
+		delegate.setColor(c);
+	}
+
+	public void setPaintMode() {
+		delegate.setPaintMode();
+	}
+
+	public void setXORMode(Color c1) {
+		delegate.setXORMode(c1);
+	}
+
+	public Font getFont() {
+		return delegate.getFont();
+	}
+
+	public void setFont(Font font) {
+		delegate.setFont(font);
+	}
+
+	public FontMetrics getFontMetrics() {
+		return delegate.getFontMetrics();
+	}
+
+	public FontMetrics getFontMetrics(Font f) {
+		return delegate.getFontMetrics(f);
+	}
+
+	public Rectangle getClipBounds() {
+		return delegate.getClipBounds();
+	}
+
+	public void clipRect(int x, int y, int width, int height) {
+		delegate.clipRect(x, y, width, height);
+	}
+
+	public void setClip(int x, int y, int width, int height) {
+		delegate.setClip(x, y, width, height);
+	}
+
+	public Shape getClip() {
+		return delegate.getClip();
+	}
+
+	public void setClip(Shape clip) {
+		delegate.setClip(clip);
+	}
+
+	public void copyArea(int x, int y, int width, int height, int dx, int dy) {
+		delegate.copyArea(x, y, width, height, dx, dy);
+	}
+
+	public void drawLine(int x1, int y1, int x2, int y2) {
+		delegate.drawLine(x1, y1, x2, y2);
+	}
+
+	public void fillRect(int x, int y, int width, int height) {
+		delegate.fillRect(x, y, width, height);
+	}
+
+	public void drawRect(int x, int y, int width, int height) {
+		delegate.drawRect(x, y, width, height);
+	}
+
+	public void drawRoundRect(int x, int y, int width, int height, int arcWidth, int arcHeight) {
+		delegate.drawRoundRect(x, y, width, height, arcWidth, arcHeight);
+	}
+
+	public void fillRoundRect(int x, int y, int width, int height, int arcWidth, int arcHeight) {
+		delegate.fillRoundRect(x, y, width, height, arcWidth, arcHeight);
+	}
+
+	public void draw3DRect(int x, int y, int width, int height, boolean raised) {
+		delegate.draw3DRect(x, y, width, height, raised);
+	}
+
+	public void fill3DRect(int x, int y, int width, int height, boolean raised) {
+		delegate.fill3DRect(x, y, width, height, raised);
+	}
+
+	public void drawOval(int x, int y, int width, int height) {
+		delegate.drawOval(x, y, width, height);
+	}
+
+	public void fillOval(int x, int y, int width, int height) {
+		delegate.fillOval(x, y, width, height);
+	}
+
+	public void drawArc(int x, int y, int width, int height, int startAngle, int arcAngle) {
+		delegate.drawArc(x, y, width, height, startAngle, arcAngle);
+	}
+
+	public void fillArc(int x, int y, int width, int height, int startAngle, int arcAngle) {
+		delegate.fillArc(x, y, width, height, startAngle, arcAngle);
+	}
+
+	public void drawPolyline(int[] xPoints, int[] yPoints, int nPoints) {
+		delegate.drawPolyline(xPoints, yPoints, nPoints);
+	}
+
+	public void drawPolygon(int[] xPoints, int[] yPoints, int nPoints) {
+		delegate.drawPolygon(xPoints, yPoints, nPoints);
+	}
+
+	public void drawPolygon(Polygon p) {
+		delegate.drawPolygon(p);
+	}
+
+	public void fillPolygon(int[] xPoints, int[] yPoints, int nPoints) {
+		delegate.fillPolygon(xPoints, yPoints, nPoints);
+	}
+
+	public void fillPolygon(Polygon p) {
+		delegate.fillPolygon(p);
+	}
+
+	public void drawString(String str, int x, int y) {
+		delegate.drawString(str, x, y);
+	}
+
+	public void drawString(AttributedCharacterIterator iterator, int x, int y) {
+		delegate.drawString(iterator, x, y);
+	}
+
+	public void drawChars(char[] data, int offset, int length, int x, int y) {
+		delegate.drawChars(data, offset, length, x, y);
+	}
+
+	public void drawBytes(byte[] data, int offset, int length, int x, int y) {
+		delegate.drawBytes(data, offset, length, x, y);
+	}
+
+	public boolean drawImage(Image img, int x, int y, ImageObserver observer) {
+		return delegate.drawImage(img, x, y, observer);
+	}
+
+	public boolean drawImage(Image img, int x, int y, int width, int height, ImageObserver observer) {
+		return delegate.drawImage(img, x, y, width, height, observer);
+	}
+
+	public boolean drawImage(Image img, int x, int y, Color bgcolor, ImageObserver observer) {
+		return delegate.drawImage(img, x, y, bgcolor, observer);
+	}
+
+	public boolean drawImage(Image img, int x, int y, int width, int height, Color bgcolor, ImageObserver observer) {
+		return delegate.drawImage(img, x, y, width, height, bgcolor, observer);
+	}
+
+	public boolean drawImage(Image img, int dx1, int dy1, int dx2, int dy2, int sx1, int sy1, int sx2, int sy2,
+			ImageObserver observer) {
+		return delegate.drawImage(img, dx1, dy1, dx2, dy2, sx1, sy1, sx2, sy2, observer);
+	}
+
+	public boolean drawImage(Image img, int dx1, int dy1, int dx2, int dy2, int sx1, int sy1, int sx2, int sy2,
+			Color bgcolor, ImageObserver observer) {
+		return delegate.drawImage(img, dx1, dy1, dx2, dy2, sx1, sy1, sx2, sy2, bgcolor, observer);
+	}
+
+	public void dispose() {
+		delegate.dispose();
+	}
+
+	public void finalize() {
+		delegate.finalize();
+	}
+
+	public String toString() {
+		return delegate.toString();
+	}
+
+	public boolean hitClip(int x, int y, int width, int height) {
+		return delegate.hitClip(x, y, width, height);
+	}
+
+	public Rectangle getClipBounds(Rectangle r) {
+		return delegate.getClipBounds(r);
+	}
+	
+}

--- a/src/org/lwjgl/awthacks/NonClearGraphics2D.java
+++ b/src/org/lwjgl/awthacks/NonClearGraphics2D.java
@@ -1,0 +1,390 @@
+package org.lwjgl.awthacks;
+
+import java.awt.Color;
+import java.awt.Composite;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Image;
+import java.awt.Paint;
+import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.RenderingHints.Key;
+import java.awt.Shape;
+import java.awt.Stroke;
+import java.awt.font.FontRenderContext;
+import java.awt.font.GlyphVector;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.awt.image.BufferedImageOp;
+import java.awt.image.ImageObserver;
+import java.awt.image.RenderedImage;
+import java.awt.image.renderable.RenderableImage;
+import java.text.AttributedCharacterIterator;
+import java.util.Map;
+
+/**
+ * Wrapper for a {@link Graphics2D} object that delegates to it.
+ * Only {@link NonClearGraphics2D#clearRect(int, int, int, int)} does
+ * not delegate in order to prevent clearing the Canvas after
+ * it was rendered.
+ * 
+ * @author hageldave
+ * @see NonClearGraphics
+ */
+public class NonClearGraphics2D extends Graphics2D {
+
+	protected Graphics2D delegate;
+	
+	public NonClearGraphics2D(Graphics2D delegate) {
+		this.delegate = delegate;
+	}
+
+	/**
+	 * Does nothing. This is to prevent a clearRect call from 
+	 * clearing the already rendered Canvas.
+	 */
+	public void clearRect(int x, int y, int width, int height) {
+		// NOOP
+	}
+
+	@Deprecated
+	public Rectangle getClipRect() {
+		return delegate.getClipRect();
+	}
+
+	public NonClearGraphics2D create() {
+		return new NonClearGraphics2D((Graphics2D)delegate.create());
+	}
+
+	public NonClearGraphics2D create(int x, int y, int width, int height) {
+		return new NonClearGraphics2D((Graphics2D)delegate.create(x, y, width, height));
+	}
+
+	public Color getColor() {
+		return delegate.getColor();
+	}
+
+	public void setColor(Color c) {
+		delegate.setColor(c);
+	}
+
+	public void setPaintMode() {
+		delegate.setPaintMode();
+	}
+
+	public void setXORMode(Color c1) {
+		delegate.setXORMode(c1);
+	}
+
+	public Font getFont() {
+		return delegate.getFont();
+	}
+
+	public void setFont(Font font) {
+		delegate.setFont(font);
+	}
+
+	public FontMetrics getFontMetrics() {
+		return delegate.getFontMetrics();
+	}
+
+	public FontMetrics getFontMetrics(Font f) {
+		return delegate.getFontMetrics(f);
+	}
+
+	public Rectangle getClipBounds() {
+		return delegate.getClipBounds();
+	}
+
+	public void clipRect(int x, int y, int width, int height) {
+		delegate.clipRect(x, y, width, height);
+	}
+
+	public void setClip(int x, int y, int width, int height) {
+		delegate.setClip(x, y, width, height);
+	}
+
+	public Shape getClip() {
+		return delegate.getClip();
+	}
+
+	public void setClip(Shape clip) {
+		delegate.setClip(clip);
+	}
+
+	public void copyArea(int x, int y, int width, int height, int dx, int dy) {
+		delegate.copyArea(x, y, width, height, dx, dy);
+	}
+
+	public void drawLine(int x1, int y1, int x2, int y2) {
+		delegate.drawLine(x1, y1, x2, y2);
+	}
+
+	public void fillRect(int x, int y, int width, int height) {
+		delegate.fillRect(x, y, width, height);
+	}
+
+	public void drawRect(int x, int y, int width, int height) {
+		delegate.drawRect(x, y, width, height);
+	}
+
+	public void draw3DRect(int x, int y, int width, int height, boolean raised) {
+		delegate.draw3DRect(x, y, width, height, raised);
+	}
+
+	public void drawRoundRect(int x, int y, int width, int height, int arcWidth, int arcHeight) {
+		delegate.drawRoundRect(x, y, width, height, arcWidth, arcHeight);
+	}
+
+	public void fill3DRect(int x, int y, int width, int height, boolean raised) {
+		delegate.fill3DRect(x, y, width, height, raised);
+	}
+
+	public void fillRoundRect(int x, int y, int width, int height, int arcWidth, int arcHeight) {
+		delegate.fillRoundRect(x, y, width, height, arcWidth, arcHeight);
+	}
+
+	public void draw(Shape s) {
+		delegate.draw(s);
+	}
+
+	public boolean drawImage(Image img, AffineTransform xform, ImageObserver obs) {
+		return delegate.drawImage(img, xform, obs);
+	}
+
+	public void drawImage(BufferedImage img, BufferedImageOp op, int x, int y) {
+		delegate.drawImage(img, op, x, y);
+	}
+
+	public void drawOval(int x, int y, int width, int height) {
+		delegate.drawOval(x, y, width, height);
+	}
+
+	public void drawRenderedImage(RenderedImage img, AffineTransform xform) {
+		delegate.drawRenderedImage(img, xform);
+	}
+
+	public void fillOval(int x, int y, int width, int height) {
+		delegate.fillOval(x, y, width, height);
+	}
+
+	public void drawArc(int x, int y, int width, int height, int startAngle, int arcAngle) {
+		delegate.drawArc(x, y, width, height, startAngle, arcAngle);
+	}
+
+	public void drawRenderableImage(RenderableImage img, AffineTransform xform) {
+		delegate.drawRenderableImage(img, xform);
+	}
+
+	public void drawString(String str, int x, int y) {
+		delegate.drawString(str, x, y);
+	}
+
+	public void fillArc(int x, int y, int width, int height, int startAngle, int arcAngle) {
+		delegate.fillArc(x, y, width, height, startAngle, arcAngle);
+	}
+
+	public void drawString(String str, float x, float y) {
+		delegate.drawString(str, x, y);
+	}
+
+	public void drawPolyline(int[] xPoints, int[] yPoints, int nPoints) {
+		delegate.drawPolyline(xPoints, yPoints, nPoints);
+	}
+
+	public void drawString(AttributedCharacterIterator iterator, int x, int y) {
+		delegate.drawString(iterator, x, y);
+	}
+
+	public void drawPolygon(int[] xPoints, int[] yPoints, int nPoints) {
+		delegate.drawPolygon(xPoints, yPoints, nPoints);
+	}
+
+	public void drawString(AttributedCharacterIterator iterator, float x, float y) {
+		delegate.drawString(iterator, x, y);
+	}
+
+	public void drawPolygon(Polygon p) {
+		delegate.drawPolygon(p);
+	}
+
+	public void fillPolygon(int[] xPoints, int[] yPoints, int nPoints) {
+		delegate.fillPolygon(xPoints, yPoints, nPoints);
+	}
+
+	public void drawGlyphVector(GlyphVector g, float x, float y) {
+		delegate.drawGlyphVector(g, x, y);
+	}
+
+	public void fillPolygon(Polygon p) {
+		delegate.fillPolygon(p);
+	}
+
+	public void fill(Shape s) {
+		delegate.fill(s);
+	}
+
+	public boolean hit(Rectangle rect, Shape s, boolean onStroke) {
+		return delegate.hit(rect, s, onStroke);
+	}
+
+	public void drawChars(char[] data, int offset, int length, int x, int y) {
+		delegate.drawChars(data, offset, length, x, y);
+	}
+
+	public GraphicsConfiguration getDeviceConfiguration() {
+		return delegate.getDeviceConfiguration();
+	}
+
+	public void setComposite(Composite comp) {
+		delegate.setComposite(comp);
+	}
+
+	public void drawBytes(byte[] data, int offset, int length, int x, int y) {
+		delegate.drawBytes(data, offset, length, x, y);
+	}
+
+	public void setPaint(Paint paint) {
+		delegate.setPaint(paint);
+	}
+
+	public boolean drawImage(Image img, int x, int y, ImageObserver observer) {
+		return delegate.drawImage(img, x, y, observer);
+	}
+
+	public void setStroke(Stroke s) {
+		delegate.setStroke(s);
+	}
+
+	public void setRenderingHint(Key hintKey, Object hintValue) {
+		delegate.setRenderingHint(hintKey, hintValue);
+	}
+
+	public Object getRenderingHint(Key hintKey) {
+		return delegate.getRenderingHint(hintKey);
+	}
+
+	public boolean drawImage(Image img, int x, int y, int width, int height, ImageObserver observer) {
+		return delegate.drawImage(img, x, y, width, height, observer);
+	}
+
+	public void setRenderingHints(Map<?, ?> hints) {
+		delegate.setRenderingHints(hints);
+	}
+
+	public void addRenderingHints(Map<?, ?> hints) {
+		delegate.addRenderingHints(hints);
+	}
+
+	public RenderingHints getRenderingHints() {
+		return delegate.getRenderingHints();
+	}
+
+	public boolean drawImage(Image img, int x, int y, Color bgcolor, ImageObserver observer) {
+		return delegate.drawImage(img, x, y, bgcolor, observer);
+	}
+
+	public void translate(int x, int y) {
+		delegate.translate(x, y);
+	}
+
+	public void translate(double tx, double ty) {
+		delegate.translate(tx, ty);
+	}
+
+	public void rotate(double theta) {
+		delegate.rotate(theta);
+	}
+
+	public boolean drawImage(Image img, int x, int y, int width, int height, Color bgcolor, ImageObserver observer) {
+		return delegate.drawImage(img, x, y, width, height, bgcolor, observer);
+	}
+
+	public void rotate(double theta, double x, double y) {
+		delegate.rotate(theta, x, y);
+	}
+
+	public void scale(double sx, double sy) {
+		delegate.scale(sx, sy);
+	}
+
+	public void shear(double shx, double shy) {
+		delegate.shear(shx, shy);
+	}
+
+	public boolean drawImage(Image img, int dx1, int dy1, int dx2, int dy2, int sx1, int sy1, int sx2, int sy2,
+			ImageObserver observer) {
+		return delegate.drawImage(img, dx1, dy1, dx2, dy2, sx1, sy1, sx2, sy2, observer);
+	}
+
+	public void transform(AffineTransform Tx) {
+		delegate.transform(Tx);
+	}
+
+	public void setTransform(AffineTransform Tx) {
+		delegate.setTransform(Tx);
+	}
+
+	public AffineTransform getTransform() {
+		return delegate.getTransform();
+	}
+
+	public boolean drawImage(Image img, int dx1, int dy1, int dx2, int dy2, int sx1, int sy1, int sx2, int sy2,
+			Color bgcolor, ImageObserver observer) {
+		return delegate.drawImage(img, dx1, dy1, dx2, dy2, sx1, sy1, sx2, sy2, bgcolor, observer);
+	}
+
+	public Paint getPaint() {
+		return delegate.getPaint();
+	}
+
+	public Composite getComposite() {
+		return delegate.getComposite();
+	}
+
+	public void setBackground(Color color) {
+		delegate.setBackground(color);
+	}
+
+	public Color getBackground() {
+		return delegate.getBackground();
+	}
+
+	public Stroke getStroke() {
+		return delegate.getStroke();
+	}
+
+	public void clip(Shape s) {
+		delegate.clip(s);
+	}
+
+	public FontRenderContext getFontRenderContext() {
+		return delegate.getFontRenderContext();
+	}
+
+	public void dispose() {
+		delegate.dispose();
+	}
+
+	public void finalize() {
+		delegate.finalize();
+	}
+
+	public String toString() {
+		return delegate.toString();
+	}
+
+	public boolean hitClip(int x, int y, int width, int height) {
+		return delegate.hitClip(x, y, width, height);
+	}
+
+	public Rectangle getClipBounds(Rectangle r) {
+		return delegate.getClipBounds(r);
+	}
+	
+	
+	
+}

--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -2,8 +2,12 @@ package org.lwjgl.opengl.awt;
 
 import java.awt.AWTException;
 import java.awt.Canvas;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.util.concurrent.*;
 
+import org.lwjgl.awthacks.NonClearGraphics;
+import org.lwjgl.awthacks.NonClearGraphics2D;
 import org.lwjgl.system.Platform;
 
 /**
@@ -113,6 +117,18 @@ public abstract class AWTGLCanvas extends Canvas {
 
     public final void swapBuffers() {
         platformCanvas.swapBuffers();
+    }
+    
+    /**
+     * Returns Graphics object that ignores {@link Graphics#clearRect(int, int, int, int)}
+     * calls.
+     * This is done so that the frame buffer will not be cleared by AWT/Swing internals.
+     */
+    @Override
+    public Graphics getGraphics() {
+    	Graphics graphics = super.getGraphics();
+    	return (graphics instanceof Graphics2D) ? 
+    			new NonClearGraphics2D((Graphics2D) graphics) : new NonClearGraphics(graphics);
     }
 
 }

--- a/test/org/lwjgl/opengl/awt/DrawOnDemandTest.java
+++ b/test/org/lwjgl/opengl/awt/DrawOnDemandTest.java
@@ -1,0 +1,87 @@
+package org.lwjgl.opengl.awt;
+
+import static org.lwjgl.opengl.GL11.glClearColor;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.event.ComponentAdapter;
+
+import javax.swing.JColorChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL11;
+
+public class DrawOnDemandTest {
+	
+	static Color quadColor = new Color(0x77aadd);
+
+	public static void main(String[] args) {
+		
+		AWTGLCanvas canvas = new AWTGLCanvas() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void initGL() {
+				GL.createCapabilities();
+				glClearColor(0.3f, 0.4f, 0.5f, 1);
+			}
+			
+			@Override
+			public void paintGL() {
+				int w = getWidth();
+				int h = getHeight();
+				if (w == 0 || h == 0) {
+					return;
+				}
+				float aspect = (float) w / h;
+				GL11.glClear(GL11.GL_COLOR_BUFFER_BIT);
+				GL11.glViewport(0, 0, w, h);
+				GL11.glBegin(GL11.GL_QUADS);
+				GL11.glColor3f(quadColor.getRed()/255f, quadColor.getGreen()/255f, quadColor.getBlue()/255f);
+				GL11.glVertex2f(-0.75f / aspect, 0.0f);
+				GL11.glVertex2f(0, -0.75f);
+				GL11.glVertex2f(+0.75f / aspect, 0);
+				GL11.glVertex2f(0, +0.75f);
+				GL11.glEnd();
+				swapBuffers();
+			}
+
+			@Override
+			public void repaint() {
+				if (SwingUtilities.isEventDispatchThread()) {
+					render();
+				} else {
+					SwingUtilities.invokeLater(() -> render());
+				}
+			}
+
+		};
+
+		JFrame frame = new JFrame();
+		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		frame.getContentPane().setLayout(new BorderLayout());
+		frame.getContentPane().add(canvas, BorderLayout.CENTER);
+		canvas.setPreferredSize(new Dimension(200, 200));
+		canvas.addComponentListener(new ComponentAdapter() {
+			public void componentResized(java.awt.event.ComponentEvent e) {
+				canvas.repaint();
+			};
+		});
+		JColorChooser colorChooser = new JColorChooser(quadColor);
+		frame.getContentPane().add(colorChooser, BorderLayout.SOUTH);
+		colorChooser.getSelectionModel().addChangeListener((e)->{
+			quadColor = colorChooser.getColor();
+			canvas.repaint();
+		});
+		
+
+		SwingUtilities.invokeLater(() -> {
+			frame.pack();
+			frame.setVisible(true);
+		});
+	}
+
+}


### PR DESCRIPTION
… and using them in AWTGLCanvas getGraphics() to prevent clearing through the Canvas' Graphics object.

Refs #13 
This probably also needs to be done for AWTVKCanvas but I wasnt able to test this.
The reason for two instead of one wrapper classes ```NonClearGraphics``` and ```NonClearGraphics2D``` is that I'm unsure whether there is a guarantee that ```Canvas.getGraphics()``` returns a Graphics2D object, and I want to still make sure that users can still use the popular ```Graphics2D g2d = (Graphics2D) graphics;``` cast when the graphics object is an instance of it.