### PR TITLE
sharing gl context between AWTGLCanvases for linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.lwjglx</groupId>
 	<artifactId>lwjgl3-awt</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 	<name>LWJGLX/lwjgl3-awt</name>
 	<description>LWJGLX/lwjgl3-awt</description>
 	<inceptionYear>2016</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.lwjglx</groupId>
 	<artifactId>lwjgl3-awt</artifactId>
-	<version>0.1.5-SNAPSHOT</version>
+	<version>0.1.5</version>
 	<name>LWJGLX/lwjgl3-awt</name>
 	<description>LWJGLX/lwjgl3-awt</description>
 	<inceptionYear>2016</inceptionYear>

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -8,6 +8,7 @@ import static org.lwjgl.opengl.GLX13.*;
 import java.awt.AWTException;
 import java.awt.Canvas;
 import java.nio.IntBuffer;
+import java.util.Objects;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
@@ -16,6 +17,7 @@ import org.lwjgl.system.jawt.JAWTDrawingSurface;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
 import org.lwjgl.system.jawt.JAWTX11DrawingSurfaceInfo;
 import org.lwjgl.system.linux.X11;
+import org.lwjgl.system.linux.XVisualInfo;
 
 public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	public static final JAWT awt;
@@ -48,7 +50,13 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 			// No framebuffer configurations supported!
 			throw new AWTException("No supported framebuffer configurations found");
 		}
-		long context = glXCreateNewContext(display, fbConfigs.get(0), GLX_RGBA_TYPE, NULL, true);
+		
+		long context;
+		if(attribs.shareContext != null){
+	    	context = glXCreateContext(display, glXGetVisualFromFBConfig(display, fbConfigs.get(0)), attribs.shareContext.context, true);
+		} else {
+			context = glXCreateNewContext(display, fbConfigs.get(0), GLX_RGBA_TYPE, NULL, true);
+		}
 		return context;
 	}
 

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -49,12 +49,8 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 			throw new AWTException("No supported framebuffer configurations found");
 		}
 		
-		long context;
-		if(attribs.shareContext != null){
-	    	context = glXCreateContext(display, glXGetVisualFromFBConfig(display, fbConfigs.get(0)), attribs.shareContext.context, true);
-		} else {
-			context = glXCreateNewContext(display, fbConfigs.get(0), GLX_RGBA_TYPE, NULL, true);
-		}
+		long share_list = attribs.shareContext == null ? NULL:attribs.shareContext.context;
+		long context = glXCreateNewContext(display, fbConfigs.get(0), GLX_RGBA_TYPE, share_list, true);
 		return context;
 	}
 

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -1,14 +1,36 @@
 package org.lwjgl.opengl.awt;
 
-import static org.lwjgl.system.jawt.JAWTFunctions.*;
-import static org.lwjgl.system.MemoryUtil.*;
-import static org.lwjgl.opengl.GLX.*;
-import static org.lwjgl.opengl.GLX13.*;
+import static org.lwjgl.opengl.GLX.GLX_BLUE_SIZE;
+import static org.lwjgl.opengl.GLX.GLX_DEPTH_SIZE;
+import static org.lwjgl.opengl.GLX.GLX_DOUBLEBUFFER;
+import static org.lwjgl.opengl.GLX.GLX_GREEN_SIZE;
+import static org.lwjgl.opengl.GLX.GLX_RED_SIZE;
+import static org.lwjgl.opengl.GLX.glXCreateContext;
+import static org.lwjgl.opengl.GLX.glXGetCurrentContext;
+import static org.lwjgl.opengl.GLX.glXMakeCurrent;
+import static org.lwjgl.opengl.GLX.glXSwapBuffers;
+import static org.lwjgl.opengl.GLX13.GLX_DRAWABLE_TYPE;
+import static org.lwjgl.opengl.GLX13.GLX_RENDER_TYPE;
+import static org.lwjgl.opengl.GLX13.GLX_RGBA_BIT;
+import static org.lwjgl.opengl.GLX13.GLX_RGBA_TYPE;
+import static org.lwjgl.opengl.GLX13.GLX_WINDOW_BIT;
+import static org.lwjgl.opengl.GLX13.glXChooseFBConfig;
+import static org.lwjgl.opengl.GLX13.glXCreateNewContext;
+import static org.lwjgl.opengl.GLX13.glXGetVisualFromFBConfig;
+import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_DrawingSurface_FreeDrawingSurfaceInfo;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_DrawingSurface_GetDrawingSurfaceInfo;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_DrawingSurface_Lock;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_DrawingSurface_Unlock;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_FreeDrawingSurface;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_GetAWT;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_GetDrawingSurface;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_LOCK_ERROR;
+import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_VERSION_1_4;
 
 import java.awt.AWTException;
 import java.awt.Canvas;
 import java.nio.IntBuffer;
-import java.util.Objects;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
@@ -17,7 +39,6 @@ import org.lwjgl.system.jawt.JAWTDrawingSurface;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
 import org.lwjgl.system.jawt.JAWTX11DrawingSurfaceInfo;
 import org.lwjgl.system.linux.X11;
-import org.lwjgl.system.linux.XVisualInfo;
 
 public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	public static final JAWT awt;

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -1,32 +1,9 @@
 package org.lwjgl.opengl.awt;
 
-import static org.lwjgl.opengl.GLX.GLX_BLUE_SIZE;
-import static org.lwjgl.opengl.GLX.GLX_DEPTH_SIZE;
-import static org.lwjgl.opengl.GLX.GLX_DOUBLEBUFFER;
-import static org.lwjgl.opengl.GLX.GLX_GREEN_SIZE;
-import static org.lwjgl.opengl.GLX.GLX_RED_SIZE;
-import static org.lwjgl.opengl.GLX.glXCreateContext;
-import static org.lwjgl.opengl.GLX.glXGetCurrentContext;
-import static org.lwjgl.opengl.GLX.glXMakeCurrent;
-import static org.lwjgl.opengl.GLX.glXSwapBuffers;
-import static org.lwjgl.opengl.GLX13.GLX_DRAWABLE_TYPE;
-import static org.lwjgl.opengl.GLX13.GLX_RENDER_TYPE;
-import static org.lwjgl.opengl.GLX13.GLX_RGBA_BIT;
-import static org.lwjgl.opengl.GLX13.GLX_RGBA_TYPE;
-import static org.lwjgl.opengl.GLX13.GLX_WINDOW_BIT;
-import static org.lwjgl.opengl.GLX13.glXChooseFBConfig;
-import static org.lwjgl.opengl.GLX13.glXCreateNewContext;
-import static org.lwjgl.opengl.GLX13.glXGetVisualFromFBConfig;
-import static org.lwjgl.system.MemoryUtil.NULL;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_DrawingSurface_FreeDrawingSurfaceInfo;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_DrawingSurface_GetDrawingSurfaceInfo;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_DrawingSurface_Lock;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_DrawingSurface_Unlock;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_FreeDrawingSurface;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_GetAWT;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_GetDrawingSurface;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_LOCK_ERROR;
-import static org.lwjgl.system.jawt.JAWTFunctions.JAWT_VERSION_1_4;
+import static org.lwjgl.system.jawt.JAWTFunctions.*;
+import static org.lwjgl.system.MemoryUtil.*;
+import static org.lwjgl.opengl.GLX.*;
+import static org.lwjgl.opengl.GLX13.*;
 
 import java.awt.AWTException;
 import java.awt.Canvas;


### PR DESCRIPTION
This already existed for windows, this enables the `GLData.shareContext` attribute to be respected in `PlatformLinuxGLCanvas` as well.
refs #16 

I'm not quite sure if this is the right way to do it, but I tested it and it worked.