### PR TITLE
swapping share list arguments to WGL.wglShareLists(..) method in PlatformWin32GLCanvas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.lwjglx</groupId>
 	<artifactId>lwjgl3-awt</artifactId>
-	<version>0.1.6</version>
+	<version>0.1.7</version>
 	<name>LWJGLX/lwjgl3-awt</name>
 	<description>LWJGLX/lwjgl3-awt</description>
 	<inceptionYear>2016</inceptionYear>

--- a/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
@@ -334,7 +334,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
 
             /* Check if we want to share context */
             if (attribs.shareContext != null) {
-                success = WGL.wglShareLists(context, attribs.shareContext.context);
+                success = WGL.wglShareLists(attribs.shareContext.context, context);
                 if (!success) {
                     User32.ReleaseDC(windowHandle, hDC);
                     WGL.wglMakeCurrent(currentDc, currentContext);


### PR DESCRIPTION
swaps the arguments to the WGL.wglShareLists(long,long) method. See issue #18