### PR TITLE
Mark lwjgl-opengl and lwjgl-vulkan as optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,7 @@
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl-opengl</artifactId>
 			<version>${lwjgl.version}</version>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.lwjgl</groupId>
@@ -302,6 +303,7 @@
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl-vulkan</artifactId>
 			<version>${lwjgl.version}</version>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
If you are only using OpenGL, you don't need the Vulkan libraries and vice versa.

This prevents polluting the dependency tree with unneeded stuff.