### PR TITLE
Altered switch statements (& unboxed int to string conversion)

### DIFF
--- a/src/org/lwjgl/vulkan/awt/AWTVKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/AWTVKCanvas.java
@@ -12,32 +12,21 @@ import java.awt.*;
  */
 public abstract class AWTVKCanvas extends Canvas {
     private static final long serialVersionUID = 1L;
-    private static PlatformVKCanvas platformCanvas;
+    private static final PlatformVKCanvas platformCanvas;
     static {
-        String platformClassName;
+        // Enhanced switch would work better :(
         switch (Platform.get()) {
         case WINDOWS:
-            platformClassName = "org.lwjgl.vulkan.awt.PlatformWin32VKCanvas";
+            platformCanvas = new PlatformWin32VKCanvas();
             break;
         case LINUX:
-            platformClassName = "org.lwjgl.vulkan.awt.PlatformX11VKCanvas";
+            platformCanvas = new PlatformX11VKCanvas();
             break;
         case MACOSX:
-            platformClassName = "org.lwjgl.vulkan.awt.PlatformMacOSXVKCanvas";
+            platformCanvas = new PlatformMacOSXVKCanvas();
             break;
         default:
             throw new AssertionError("NYI");
-        }
-        try {
-            @SuppressWarnings("unchecked")
-            Class<? extends PlatformVKCanvas> clazz = (Class<? extends PlatformVKCanvas>) AWTVKCanvas.class.getClassLoader().loadClass(platformClassName);
-            platformCanvas = clazz.newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new AssertionError("Platform-specific VKCanvas class not found: " + platformClassName);
-        } catch (InstantiationException e) {
-            throw new AssertionError("Could not instantiate platform-specific VKCanvas class: " + platformClassName);
-        } catch (IllegalAccessException e) {
-            throw new AssertionError("Could not instantiate platform-specific VKCanvas class: " + platformClassName);
         }
     }
 

--- a/test/org/lwjgl/vulkan/awt/SimpleDemo.java
+++ b/test/org/lwjgl/vulkan/awt/SimpleDemo.java
@@ -39,14 +39,29 @@ public class SimpleDemo {
                 .pApplicationName(memUTF8("AWT Vulkan Demo"))
                 .pEngineName(memUTF8(""))
                 .apiVersion(VK_MAKE_VERSION(1, 0, 2));
+
+        // Enhanced switch statement would work better :(
+        String surfaceExtension;
+        switch (Platform.get()) {
+            case WINDOWS: {
+                surfaceExtension = VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
+                break;
+            }
+            case LINUX: {
+                surfaceExtension = VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
+                break;
+            }
+            case MACOSX: {
+                surfaceExtension = VK_EXT_METAL_SURFACE_EXTENSION_NAME;
+                break;
+            }
+            default: throw new RuntimeException("Failed to find the appropriate platform surface extension.");
+        }
+
+
         ByteBuffer VK_KHR_SURFACE_EXTENSION = memUTF8(VK_KHR_SURFACE_EXTENSION_NAME);
-        ByteBuffer VK_KHR_OS_SURFACE_EXTENSION;
-        if (Platform.get() == Platform.WINDOWS)
-            VK_KHR_OS_SURFACE_EXTENSION = memUTF8(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-        else if (Platform.get() == Platform.LINUX)
-            VK_KHR_OS_SURFACE_EXTENSION = memUTF8(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-        else
-            VK_KHR_OS_SURFACE_EXTENSION = memUTF8(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
+        ByteBuffer VK_KHR_OS_SURFACE_EXTENSION = memUTF8(surfaceExtension);
+
         PointerBuffer ppEnabledExtensionNames = memAllocPointer(2);
         ppEnabledExtensionNames.put(VK_KHR_SURFACE_EXTENSION);
         ppEnabledExtensionNames.put(VK_KHR_OS_SURFACE_EXTENSION);

--- a/test/org/lwjgl/vulkan/awt/VKUtil.java
+++ b/test/org/lwjgl/vulkan/awt/VKUtil.java
@@ -69,7 +69,7 @@ public class VKUtil {
         case VK_ERROR_VALIDATION_FAILED_EXT:
             return "A validation layer found an error.";
         default:
-            return String.format("%s [%d]", "Unknown", Integer.valueOf(result));
+            return String.format("%s [%d]", "Unknown", result);
         }
     }
 


### PR DESCRIPTION
AWTVKCanvas class currently loads the class by a string, rather than doing it right in the switch statement (why was this done?). The Vulkan demo had else-if statements, and would benefit from using a switch for cleanliness sake. I also removed `Integer.valueOf()` in the `VKUtil.java` class.