### PR TITLE
Patch Memory Leaks in Vulkan Classes

### DIFF
--- a/lwjgl3awt/org_lwjgl_vulkan_awt_PlatformMacOSXVKCanvas.m
+++ b/lwjgl3awt/org_lwjgl_vulkan_awt_PlatformMacOSXVKCanvas.m
@@ -1,5 +1,4 @@
 
-
 #import <MetalKit/MetalKit.h>
 #include <JavaVM/jawt_md.h>
 #include "org_lwjgl_opengl_awt_PlatformMacOSXGLCanvas.h"

--- a/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
@@ -10,13 +10,11 @@ import org.lwjgl.system.macosx.ObjCRuntime;
 import org.lwjgl.vulkan.VkMetalSurfaceCreateInfoEXT;
 import org.lwjgl.vulkan.VkPhysicalDevice;
 
-import javax.swing.JRootPane;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 import java.awt.*;
 import java.nio.LongBuffer;
 
 import static org.lwjgl.system.JNI.invokePPP;
-import static org.lwjgl.system.MemoryUtil.memAllocLong;
 import static org.lwjgl.system.jawt.JAWTFunctions.*;
 import static org.lwjgl.system.macosx.ObjCRuntime.objc_getClass;
 import static org.lwjgl.system.macosx.ObjCRuntime.sel_getUid;
@@ -30,7 +28,7 @@ public class PlatformMacOSXVKCanvas implements PlatformVKCanvas {
     private static final long objc_msgSend;
     private static final long CATransaction;
     static {
-        awt = JAWT.calloc();
+        awt = JAWT.callocStack();
         awt.version(JAWT_VERSION_1_7);
         if (!JAWT_GetAWT(awt))
             throw new AssertionError("GetAWT failed");

--- a/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
@@ -48,7 +48,6 @@ public class PlatformMacOSXVKCanvas implements PlatformVKCanvas {
 
     public long create(Canvas canvas, VKData data) throws AWTException {
         MemoryStack stack = MemoryStack.stackGet();
-        int ptr = stack.getPointer();
         JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         try {
             int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
@@ -71,16 +70,12 @@ public class PlatformMacOSXVKCanvas implements PlatformVKCanvas {
                             .sType(VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT)
                             .flags(0)
                             .pLayer(pLayer);
-                    LongBuffer surfaceAddr = memAllocLong(1);
-                    surfaceAddr.put(stack.nmalloc(8, 8));
-                    surfaceAddr.rewind();
-                    int err = vkCreateMetalSurfaceEXT(data.instance, sci, null, surfaceAddr);
-                    long surface = surfaceAddr.get(0);
-                    stack.setPointer(ptr);
+                    LongBuffer pSurface = stack.mallocLong(1);
+                    int err = vkCreateMetalSurfaceEXT(data.instance, sci, null, pSurface);
                     if (err != VK_SUCCESS) {
                         throw new AWTException("Calling vkCreateMetalSurfaceEXT failed with error: " + err);
                     }
-                    return surface;
+                    return pSurface.get(0);
                 } finally {
                     JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
                 }

--- a/src/org/lwjgl/vulkan/awt/PlatformWin32VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformWin32VKCanvas.java
@@ -1,16 +1,6 @@
 package org.lwjgl.vulkan.awt;
 
-import static org.lwjgl.system.jawt.JAWTFunctions.*;
-import static org.lwjgl.vulkan.KHRWin32Surface.*;
-import static org.lwjgl.vulkan.VK10.*;
-
-import java.awt.AWTException;
-import java.awt.Canvas;
-import java.nio.ByteBuffer;
-import java.nio.LongBuffer;
-
 import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.jawt.JAWT;
 import org.lwjgl.system.jawt.JAWTDrawingSurface;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
@@ -18,6 +8,14 @@ import org.lwjgl.system.jawt.JAWTWin32DrawingSurfaceInfo;
 import org.lwjgl.system.windows.WinBase;
 import org.lwjgl.vulkan.VkPhysicalDevice;
 import org.lwjgl.vulkan.VkWin32SurfaceCreateInfoKHR;
+
+import java.awt.*;
+import java.nio.ByteBuffer;
+import java.nio.LongBuffer;
+
+import static org.lwjgl.system.jawt.JAWTFunctions.*;
+import static org.lwjgl.vulkan.KHRWin32Surface.*;
+import static org.lwjgl.vulkan.VK10.VK_SUCCESS;
 
 /**
  * Window-specific implementation of {@link PlatformVKCanvas}.
@@ -27,7 +25,7 @@ import org.lwjgl.vulkan.VkWin32SurfaceCreateInfoKHR;
 public class PlatformWin32VKCanvas implements PlatformVKCanvas {
     private static final JAWT awt;
     static {
-        awt = JAWT.calloc();
+        awt = JAWT.callocStack();
         awt.version(JAWT_VERSION_1_4);
         if (!JAWT_GetAWT(awt))
             throw new AssertionError("GetAWT failed");

--- a/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
@@ -1,7 +1,6 @@
 package org.lwjgl.vulkan.awt;
 
 import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.jawt.JAWT;
 import org.lwjgl.system.jawt.JAWTDrawingSurface;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
@@ -14,13 +13,14 @@ import java.awt.*;
 import java.nio.LongBuffer;
 
 import static org.lwjgl.system.jawt.JAWTFunctions.*;
-import static org.lwjgl.vulkan.KHRXlibSurface.*;
+import static org.lwjgl.vulkan.KHRXlibSurface.VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+import static org.lwjgl.vulkan.KHRXlibSurface.vkCreateXlibSurfaceKHR;
 import static org.lwjgl.vulkan.VK10.VK_SUCCESS;
 
 public class PlatformX11VKCanvas implements PlatformVKCanvas {
     private static final JAWT awt;
     static {
-        awt = JAWT.calloc();
+        awt = JAWT.callocStack();
         awt.version(JAWT_VERSION_1_4);
         if (!JAWT_GetAWT(awt))
             throw new AssertionError("GetAWT failed");

--- a/src/org/lwjgl/vulkan/awt/VKData.java
+++ b/src/org/lwjgl/vulkan/awt/VKData.java
@@ -1,8 +1,8 @@
 package org.lwjgl.vulkan.awt;
 
-import java.awt.Canvas;
-
 import org.lwjgl.vulkan.VkInstance;
+
+import java.awt.*;
 
 /**
  * Contains necessary data to create an {@link AWTVKCanvas}.
@@ -16,4 +16,20 @@ public class VKData {
      */
     public VkInstance instance;
 
+    /**
+     * Sets the {@link #instance instance field} and returns this object.
+     * @param instance Vulkan instance
+     * @return this
+     */
+    public VKData setInstance(VkInstance instance) {
+    	this.instance = instance;
+    	return this;
+    }
+
+    /**
+     * @return the {@link #instance instance field}
+     */
+    public VkInstance getInstance() {
+        return instance;
+    }
 }

--- a/test/org/lwjgl/vulkan/awt/SimpleDemo.java
+++ b/test/org/lwjgl/vulkan/awt/SimpleDemo.java
@@ -86,8 +86,7 @@ public class SimpleDemo {
     public static void main(String[] args) {
         // Create the Vulkan instance
         VkInstance instance = createInstance();
-        VKData data = new VKData();
-        data.instance = instance; // <- set Vulkan instance
+        VKData data = new VKData().setInstance(instance); // <- set Vulkan instance
         JFrame frame = new JFrame("AWT test");
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         frame.setLayout(new BorderLayout());

--- a/test/org/lwjgl/vulkan/awt/SimpleDemo.java
+++ b/test/org/lwjgl/vulkan/awt/SimpleDemo.java
@@ -3,12 +3,15 @@ package org.lwjgl.vulkan.awt;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.Platform;
+import org.lwjgl.vulkan.KHRSurface;
 import org.lwjgl.vulkan.VkApplicationInfo;
 import org.lwjgl.vulkan.VkInstance;
 import org.lwjgl.vulkan.VkInstanceCreateInfo;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.nio.ByteBuffer;
 
 import static org.lwjgl.vulkan.EXTMetalSurface.VK_EXT_METAL_SURFACE_EXTENSION_NAME;
@@ -91,17 +94,30 @@ public class SimpleDemo {
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         frame.setLayout(new BorderLayout());
         frame.setPreferredSize(new Dimension(600, 600));
-        frame.add(new AWTVKCanvas(data) {
+        AWTVKCanvas awtvkCanvas = new AWTVKCanvas(data) {
             private static final long serialVersionUID = 1L;
+
             public void initVK() {
                 @SuppressWarnings("unused")
                 long surface = this.surface;
 
                 // Do something with surface...
             }
+
             public void paintVK() {
             }
-        }, BorderLayout.CENTER);
+        };
+        frame.add(awtvkCanvas, BorderLayout.CENTER);
+
+        frame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                super.windowClosing(e);
+
+                KHRSurface.vkDestroySurfaceKHR(instance, awtvkCanvas.surface, null);
+            }
+        });
+
         frame.pack();
         frame.setVisible(true);
     }


### PR DESCRIPTION
This PR fixes all memory leaks in the `org.lwjgl.vulkan.awt` package. This partially fixes #43, but doesn't address the OpenGL issues.

* Replaces unsafe VK10 calls with safer ones.
* `SimpleDemo` frees all of its memory automatically.
* JAWT objects are freed automatically.