### PR TITLE
Vulkan: code cleanup, documentation, and more

### DIFF
--- a/lwjgl3awt/org_lwjgl_vulkan_awt_PlatformMacOSXVKCanvas.m
+++ b/lwjgl3awt/org_lwjgl_vulkan_awt_PlatformMacOSXVKCanvas.m
@@ -7,9 +7,17 @@
 JNIEXPORT jlong JNICALL Java_org_lwjgl_vulkan_awt_PlatformMacOSXVKCanvas_createMTKView
   (JNIEnv *env, jobject object, jlong platformInfo, jint x, jint y, jint width, jint height) {
       id<JAWT_SurfaceLayers> surfaceLayers = (id)platformInfo;
+
+      // Get the preferred default Metal device object
+      // Apple spec: 10.11 (OSX El Capitan; 2018) or higher
       id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+
+      // New rectangle with fixed coordinates
+      // Apple spec: 10.0 (OSX 10; 2001) or higher
       CGRect frame = CGRectMake(x, surfaceLayers.windowLayer.frame.size.height-height-y, width, height);
+
       MTKView *view = [[MTKView alloc] initWithFrame:frame device:device];
       surfaceLayers.layer = view.layer;
+
       return (jlong) view.layer;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		</developer>
 	</developers>
 	<properties>
-		<lwjgl.version>3.2.3</lwjgl.version>
+		<lwjgl.version>3.3.0</lwjgl.version>
 		<junit.version>5.7.0</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -321,7 +321,7 @@
 		<dependency>
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl-vulkan</artifactId>
-			<version>3.2.3</version>
+			<version>${lwjgl.version}</version>
 			<classifier>natives-${platform}</classifier>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,13 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-vulkan</artifactId>
+			<version>3.2.3</version>
+			<classifier>natives-${platform}</classifier>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<version>${junit.version}</version>

--- a/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
@@ -1,56 +1,28 @@
 package org.lwjgl.opengl.awt;
 
-import static org.lwjgl.system.MemoryUtil.NULL;
-import static org.lwjgl.system.jawt.JAWTFunctions.*;
-import static org.lwjgl.system.windows.WindowsLibrary.HINSTANCE;
-import static org.lwjgl.opengl.awt.GLUtil.*;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.*;
+import org.lwjgl.opengl.awt.GLData.API;
+import org.lwjgl.opengl.awt.GLData.Profile;
+import org.lwjgl.opengl.awt.GLData.ReleaseBehavior;
+import org.lwjgl.system.*;
+import org.lwjgl.system.APIUtil.APIVersion;
+import org.lwjgl.system.jawt.JAWT;
+import org.lwjgl.system.jawt.JAWTDrawingSurface;
+import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
+import org.lwjgl.system.jawt.JAWTWin32DrawingSurfaceInfo;
+import org.lwjgl.system.windows.*;
 
-import java.awt.AWTException;
-import java.awt.Canvas;
+import java.awt.*;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.lwjgl.BufferUtils;
-import org.lwjgl.opengl.ARBMultisample;
-import org.lwjgl.opengl.ARBRobustness;
-import org.lwjgl.opengl.GL;
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL30;
-import org.lwjgl.opengl.GL32;
-import org.lwjgl.opengl.GL43;
-import org.lwjgl.opengl.NVMultisampleCoverage;
-import org.lwjgl.opengl.WGL;
-import org.lwjgl.opengl.WGLARBContextFlushControl;
-import org.lwjgl.opengl.WGLARBCreateContext;
-import org.lwjgl.opengl.WGLARBCreateContextProfile;
-import org.lwjgl.opengl.WGLARBCreateContextRobustness;
-import org.lwjgl.opengl.WGLARBMultisample;
-import org.lwjgl.opengl.WGLARBPixelFormat;
-import org.lwjgl.opengl.WGLARBPixelFormatFloat;
-import org.lwjgl.opengl.WGLARBRobustnessApplicationIsolation;
-import org.lwjgl.opengl.WGLEXTCreateContextES2Profile;
-import org.lwjgl.opengl.WGLEXTFramebufferSRGB;
-import org.lwjgl.opengl.WGLNVMultisampleCoverage;
-import org.lwjgl.opengl.awt.GLData.API;
-import org.lwjgl.opengl.awt.GLData.Profile;
-import org.lwjgl.opengl.awt.GLData.ReleaseBehavior;
-import org.lwjgl.system.APIUtil;
-import org.lwjgl.system.APIUtil.APIVersion;
-import org.lwjgl.system.Checks;
-import org.lwjgl.system.JNI;
-import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.MemoryUtil;
-import org.lwjgl.system.jawt.JAWT;
-import org.lwjgl.system.jawt.JAWTDrawingSurface;
-import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
-import org.lwjgl.system.jawt.JAWTWin32DrawingSurfaceInfo;
-import org.lwjgl.system.windows.GDI32;
-import org.lwjgl.system.windows.PIXELFORMATDESCRIPTOR;
-import org.lwjgl.system.windows.User32;
-import org.lwjgl.system.windows.WNDCLASSEX;
-import org.lwjgl.system.windows.WindowProc;
+import static org.lwjgl.opengl.awt.GLUtil.*;
+import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.system.jawt.JAWTFunctions.*;
+import static org.lwjgl.system.windows.WindowsLibrary.HINSTANCE;
 
 /**
  * Windows-specific implementation of {@link PlatformGLCanvas}.
@@ -176,7 +148,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
         validateAttributes(attribs);
 
         // Find this exact pixel format, though for now without multisampling. This comes later!
-        PIXELFORMATDESCRIPTOR pfd = PIXELFORMATDESCRIPTOR.callocStack(stack);
+        PIXELFORMATDESCRIPTOR pfd = PIXELFORMATDESCRIPTOR.calloc(stack);
         pfd.nSize((short) PIXELFORMATDESCRIPTOR.SIZEOF);
         pfd.nVersion((short) 1); // this should always be 1
         pfd.dwLayerMask(GDI32.PFD_MAIN_PLANE);
@@ -683,7 +655,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
             effective.majorVersion = version.major;
             effective.minorVersion = version.minor;
         } else if (attribs.api == API.GLES) {
-            APIVersion version = APIUtil.apiParseVersion(MemoryUtil.memUTF8(Checks.check(JNI.callP(GL11.GL_VERSION, getString))), "OpenGL ES");
+            APIVersion version = APIUtil.apiParseVersion(MemoryUtil.memUTF8(Checks.check(JNI.callP(GL11.GL_VERSION, getString))));
             effective.majorVersion = version.major;
             effective.minorVersion = version.minor;
         }

--- a/src/org/lwjgl/vulkan/awt/AWT.java
+++ b/src/org/lwjgl/vulkan/awt/AWT.java
@@ -1,0 +1,108 @@
+package org.lwjgl.vulkan.awt;
+
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.system.jawt.JAWT;
+import org.lwjgl.system.jawt.JAWTDrawingSurface;
+import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
+
+import java.awt.*;
+
+import static org.lwjgl.system.jawt.JAWTFunctions.*;
+
+/**
+ * Platform-independent implementation<sup>&#8224;</sup>.
+ * <p>
+ * &#8224; The JAWT library is initialized with different versions
+ * depending on the platform for some reason.
+ *
+ * @author SWinxy
+ * @author Kai Burjack
+ */
+public class AWT implements AutoCloseable {
+
+	private final JAWT jawt;
+	private final JAWTDrawingSurface drawingSurface;
+	private final JAWTDrawingSurfaceInfo drawingSurfaceInfo;
+
+	/**
+	 * Initializes native window handlers from the desired AWT component.
+	 * The component MUST be a {@link Component}, but should be a canvas
+	 * or window for native rendering.
+	 *
+	 * @param component a component to render onto
+	 * @throws AWTException Fails for one of the provided reasons:
+	 *                      <ul>
+	 *                          <li>if the JAWT library failed to initialize;</li>
+	 *                          <li>if the drawing surface could not be retrieved;</li>
+	 *                          <li>if JAWT failed to lock the drawing surface;</li>
+	 *                          <li>or if JAWT failed to get information about the drawing surface;</li>
+	 *                      </ul>
+	 */
+	public AWT(Component component) throws AWTException {
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+
+			jawt = JAWT
+					.callocStack(stack)
+					.version(JAWT_VERSION_1_7);
+
+			// Initialize JAWT
+			if (!JAWT_GetAWT(jawt)) {
+				throw new AWTException("Failed to initialize the native JAWT library.");
+			}
+
+			// Get the drawing surface from the canvas
+			drawingSurface = JAWT_GetDrawingSurface(component, jawt.GetDrawingSurface());
+			if (drawingSurface == null) {
+				throw new AWTException("Failed to get drawing surface.");
+			}
+
+			// Try to lock the surface for native rendering
+			int lock = JAWT_DrawingSurface_Lock(drawingSurface, drawingSurface.Lock());
+			if ((lock & JAWT_LOCK_ERROR) != 0) {
+				JAWT_FreeDrawingSurface(drawingSurface, jawt.FreeDrawingSurface());
+				throw new AWTException("Failed to lock the AWT drawing surface.");
+			}
+
+			drawingSurfaceInfo = JAWT_DrawingSurface_GetDrawingSurfaceInfo(drawingSurface, drawingSurface.GetDrawingSurfaceInfo());
+			if (drawingSurfaceInfo == null) {
+				JAWT_DrawingSurface_Unlock(drawingSurface, drawingSurface.Unlock());
+				throw new AWTException("Failed to get AWT drawing surface information.");
+			}
+
+			long address = drawingSurfaceInfo.platformInfo();
+
+			if (address == MemoryUtil.NULL) {
+				throw new AWTException("An unknown error occurred. Failed to retrieve platform-specific information.");
+			}
+		}
+	}
+
+	public static AWT create(Canvas canvas) throws AWTException {
+		return new AWT(canvas);
+	}
+
+	/**
+	 * Returns a pointer to a platform-specific struct with platform-specific information.
+	 * <p>
+	 * The pointer can be safely cast to a {@link org.lwjgl.system.jawt.JAWTWin32DrawingSurfaceInfo}
+	 * or {@link org.lwjgl.system.jawt.JAWTX11DrawingSurfaceInfo} struct, or--if on MacOS--
+	 * a pointer to an {@code NSObject}.
+	 * <p>
+	 * On win32 or X11 platforms, this can easily be created in Java via LWJGL's
+	 * {@code #create(long)} method.
+	 *
+	 * @return pointer to platform-specific data
+	 */
+	public long getPlatformInfo() {
+		return drawingSurfaceInfo.platformInfo();
+	}
+
+	@Override
+	public void close() {
+		// Free and unlock
+		JAWT_DrawingSurface_FreeDrawingSurfaceInfo(drawingSurfaceInfo, drawingSurface.FreeDrawingSurfaceInfo());
+		JAWT_DrawingSurface_Unlock(drawingSurface, drawingSurface.Unlock());
+		JAWT_FreeDrawingSurface(drawingSurface, jawt.FreeDrawingSurface());
+	}
+}

--- a/src/org/lwjgl/vulkan/awt/AWT.java
+++ b/src/org/lwjgl/vulkan/awt/AWT.java
@@ -57,7 +57,7 @@ public class AWT implements AutoCloseable {
 		try (MemoryStack stack = MemoryStack.stackPush()) {
 
 			jawt = JAWT
-					.callocStack(stack)
+					.calloc(stack)
 					.version(JAWT_VERSION_1_7);
 
 			// Initialize JAWT

--- a/src/org/lwjgl/vulkan/awt/AWT.java
+++ b/src/org/lwjgl/vulkan/awt/AWT.java
@@ -98,6 +98,10 @@ public class AWT implements AutoCloseable {
 		return drawingSurfaceInfo.platformInfo();
 	}
 
+	public JAWTDrawingSurfaceInfo getDrawingSurfaceInfo() {
+		return drawingSurfaceInfo;
+	}
+
 	@Override
 	public void close() {
 		// Free and unlock

--- a/src/org/lwjgl/vulkan/awt/AWT.java
+++ b/src/org/lwjgl/vulkan/awt/AWT.java
@@ -21,14 +21,28 @@ import static org.lwjgl.system.jawt.JAWTFunctions.*;
  */
 public class AWT implements AutoCloseable {
 
+	/**
+	 * JAWT object. Despite it being created from the stack,
+	 * it still lives on until after {@link #close()} is called.
+	 */
 	private final JAWT jawt;
+
+	/**
+	 * The drawing surface that is used.
+	 */
 	private final JAWTDrawingSurface drawingSurface;
+
+	/**
+	 * Drawing surface metadata.
+	 */
 	private final JAWTDrawingSurfaceInfo drawingSurfaceInfo;
 
 	/**
 	 * Initializes native window handlers from the desired AWT component.
 	 * The component MUST be a {@link Component}, but should be a canvas
 	 * or window for native rendering.
+	 * <p>
+	 * If not used in a try-with-resources block, call {@link #close()} when done.
 	 *
 	 * @param component a component to render onto
 	 * @throws AWTException Fails for one of the provided reasons:
@@ -78,10 +92,6 @@ public class AWT implements AutoCloseable {
 		}
 	}
 
-	public static AWT create(Canvas canvas) throws AWTException {
-		return new AWT(canvas);
-	}
-
 	/**
 	 * Returns a pointer to a platform-specific struct with platform-specific information.
 	 * <p>
@@ -102,6 +112,11 @@ public class AWT implements AutoCloseable {
 		return drawingSurfaceInfo;
 	}
 
+	/**
+	 * Frees memory and unlocks the drawing surface.
+	 * <p>
+	 * The JAWT object is implicitly freed(?).
+	 */
 	@Override
 	public void close() {
 		// Free and unlock

--- a/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
@@ -1,8 +1,10 @@
 package org.lwjgl.vulkan.awt;
 
+import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.JNI;
 import org.lwjgl.system.Library;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
 import org.lwjgl.system.jawt.JAWTRectangle;
 import org.lwjgl.system.macosx.ObjCRuntime;
@@ -11,6 +13,7 @@ import org.lwjgl.vulkan.VkPhysicalDevice;
 
 import javax.swing.*;
 import java.awt.*;
+import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 
 import static org.lwjgl.vulkan.EXTMetalSurface.VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
@@ -109,7 +112,7 @@ public class PlatformMacOSXVKCanvas implements PlatformVKCanvas {
                 VkMetalSurfaceCreateInfoEXT pCreateInfo = VkMetalSurfaceCreateInfoEXT
                         .callocStack(stack)
                         .sType(VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT)
-                        .pLayer(stack.pointers(metalLayer));
+                        .pLayer(PointerBuffer.create(metalLayer, 1));
 
                 LongBuffer pSurface = stack.mallocLong(1);
                 int result = vkCreateMetalSurfaceEXT(data.instance, pCreateInfo, null, pSurface);

--- a/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
@@ -29,9 +29,6 @@ import static org.lwjgl.vulkan.VK10.*;
  */
 public class PlatformMacOSXVKCanvas implements PlatformVKCanvas {
 
-    // 3.2.3 does not include the newest VkResult code
-    private static final int VK_ERROR_UNKNOWN = -13;
-
     // Pointer to a method that sends a message to an instance of a class
     // Apple spec: macOS 10.0 (OSX 10; 2001) or higher
     private static final long objc_msgSend;
@@ -110,7 +107,7 @@ public class PlatformMacOSXVKCanvas implements PlatformVKCanvas {
                 caFlush();
 
                 VkMetalSurfaceCreateInfoEXT pCreateInfo = VkMetalSurfaceCreateInfoEXT
-                        .callocStack(stack)
+                        .calloc(stack)
                         .sType(VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT)
                         .pLayer(PointerBuffer.create(metalLayer, 1));
 

--- a/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
@@ -84,7 +84,7 @@ public class PlatformMacOSXVKCanvas implements PlatformVKCanvas {
     private native long createMTKView(long platformInfo, int x, int y, int width, int height);
 
     public long create(Canvas canvas, VKData data) throws AWTException {
-        try (AWT awt = AWT.create(canvas)) {
+        try (AWT awt = new AWT(canvas)) {
             try (MemoryStack stack = MemoryStack.stackPush()) {
 
                 JAWTDrawingSurfaceInfo drawingSurfaceInfo = awt.getDrawingSurfaceInfo();

--- a/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformMacOSXVKCanvas.java
@@ -85,7 +85,7 @@ public class PlatformMacOSXVKCanvas implements PlatformVKCanvas {
         }
     }
 
-    // TODO: add this
+    // On macOS, all physical devices and queue families must be capable of presentation with any layer. As a result there is no macOS-specific query for these capabilities.
     public boolean getPhysicalDevicePresentationSupport(VkPhysicalDevice physicalDevice, int queueFamily) {
         return true;
     }

--- a/src/org/lwjgl/vulkan/awt/PlatformWin32VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformWin32VKCanvas.java
@@ -25,7 +25,7 @@ public class PlatformWin32VKCanvas implements PlatformVKCanvas {
     private static final int VK_ERROR_UNKNOWN = -13;
 
     public long create(Canvas canvas, VKData data) throws AWTException {
-        try (AWT awt = AWT.create(canvas)) {
+        try (AWT awt = new AWT(canvas)) {
             try (MemoryStack stack = MemoryStack.stackPush()) {
 
                 // Get ptr to win32 struct

--- a/src/org/lwjgl/vulkan/awt/PlatformWin32VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformWin32VKCanvas.java
@@ -40,25 +40,25 @@ public class PlatformWin32VKCanvas implements PlatformVKCanvas {
                 LongBuffer pSurface = stack.mallocLong(1);
                 int result = vkCreateWin32SurfaceKHR(data.instance, sci, null, pSurface);
 
-                // Possible VkResult codes returned
-                if (result == VK_SUCCESS) {
-                    return pSurface.get(0);
-                }
-                if (result == VK_ERROR_OUT_OF_HOST_MEMORY) {
-                    throw new AWTException("Failed to create a Vulkan surface: out of host memory.");
-                }
-                if (result == VK_ERROR_OUT_OF_DEVICE_MEMORY) {
-                    throw new AWTException("Failed to create a Vulkan surface: out of device memory.");
-                }
+                switch (result) {
+                    case VK_SUCCESS:
+                        return pSurface.get(0);
 
-                // Error unknown to the implementation
-                if (result == VK_ERROR_UNKNOWN) {
-                    throw new AWTException("An unknown error occurred. This may be because of an invalid input, " +
-                            "or because the Vulkan implementation has a bug.");
-                }
+                    // Possible VkResult codes returned
+                    case VK_ERROR_OUT_OF_HOST_MEMORY:
+                        throw new AWTException("Failed to create a Vulkan surface: a host memory allocation has failed.");
+                    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+                        throw new AWTException("Failed to create a Vulkan surface: a device memory allocation has failed.");
 
-                // Unknown error not included in this list
-                throw new AWTException("Calling vkCreateWin32SurfaceKHR failed with unknown Vulkan error: " + result);
+                    // Error unknown to the implementation
+                    case VK_ERROR_UNKNOWN:
+                        throw new AWTException("An unknown error has occurred;" +
+                                " either the application has provided invalid input, or an implementation failure has occurred.");
+
+                    // Unknown error not included in this list
+                    default:
+                        throw new AWTException("Calling vkCreateWin32SurfaceKHR failed with unknown Vulkan error: " + result);
+                }
             }
         }
     }

--- a/src/org/lwjgl/vulkan/awt/PlatformWin32VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformWin32VKCanvas.java
@@ -21,9 +21,6 @@ import static org.lwjgl.vulkan.VK10.*;
  */
 public class PlatformWin32VKCanvas implements PlatformVKCanvas {
 
-    // 3.2.3 does not include the newest VkResult code
-    private static final int VK_ERROR_UNKNOWN = -13;
-
     public long create(Canvas canvas, VKData data) throws AWTException {
         try (AWT awt = new AWT(canvas)) {
             try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -34,7 +31,8 @@ public class PlatformWin32VKCanvas implements PlatformVKCanvas {
                 // Gets a handle to the file used to create the calling process (.exe file)
                 long handle = WinBase.nGetModuleHandle(MemoryUtil.NULL);
 
-                VkWin32SurfaceCreateInfoKHR sci = VkWin32SurfaceCreateInfoKHR.callocStack(stack)
+                VkWin32SurfaceCreateInfoKHR sci = VkWin32SurfaceCreateInfoKHR
+                        .calloc(stack)
                         .sType(VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR)
                         .hinstance(handle)
                         .hwnd(dsiWin.hwnd());

--- a/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
@@ -1,9 +1,6 @@
 package org.lwjgl.vulkan.awt;
 
 import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.jawt.JAWT;
-import org.lwjgl.system.jawt.JAWTDrawingSurface;
-import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
 import org.lwjgl.system.jawt.JAWTX11DrawingSurfaceInfo;
 import org.lwjgl.vulkan.KHRXlibSurface;
 import org.lwjgl.vulkan.VkPhysicalDevice;
@@ -12,55 +9,54 @@ import org.lwjgl.vulkan.VkXlibSurfaceCreateInfoKHR;
 import java.awt.*;
 import java.nio.LongBuffer;
 
-import static org.lwjgl.system.jawt.JAWTFunctions.*;
-import static org.lwjgl.vulkan.KHRXlibSurface.VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
 import static org.lwjgl.vulkan.KHRXlibSurface.vkCreateXlibSurfaceKHR;
-import static org.lwjgl.vulkan.VK10.VK_SUCCESS;
+import static org.lwjgl.vulkan.VK10.*;
 
+/**
+ * X11-specific implementation of {@link PlatformVKCanvas}.
+ *
+ * @author Guenther
+ * @author SWinxy
+ */
 public class PlatformX11VKCanvas implements PlatformVKCanvas {
-    private static final JAWT awt;
-    static {
-        awt = JAWT.callocStack();
-        awt.version(JAWT_VERSION_1_4);
-        if (!JAWT_GetAWT(awt))
-            throw new AssertionError("GetAWT failed");
-    }
+
+    // 3.2.3 does not include the newest VkResult code
+    private static final int VK_ERROR_UNKNOWN = -13;
 
     @Override
     public long create(Canvas canvas, VKData data) throws AWTException {
-        MemoryStack stack = MemoryStack.stackGet();
-        JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
-        try {
-            int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
-            if ((lock & JAWT_LOCK_ERROR) != 0)
-                throw new AWTException("JAWT_DrawingSurface_Lock() failed");
-            try {
-                JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds, ds.GetDrawingSurfaceInfo());
-                try {
-                    JAWTX11DrawingSurfaceInfo dsiX11 = JAWTX11DrawingSurfaceInfo.create(dsi.platformInfo());
-                    long display = dsiX11.display();
-                    long window = dsiX11.drawable();
+        try (AWT awt = AWT.create(canvas)) {
+            try (MemoryStack stack = MemoryStack.stackPush()) {
+                JAWTX11DrawingSurfaceInfo dsiX11 = JAWTX11DrawingSurfaceInfo.create(awt.getPlatformInfo());
 
-                    VkXlibSurfaceCreateInfoKHR sci = VkXlibSurfaceCreateInfoKHR.callocStack(stack)
-                            .sType(VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR)
-                            .dpy(display)
-                            .window(window);
+                VkXlibSurfaceCreateInfoKHR pCreateInfo = VkXlibSurfaceCreateInfoKHR
+                        .callocStack(stack)
+                        .dpy(dsiX11.display())
+                        .window(dsiX11.drawable());
 
-                    LongBuffer pSurface = stack.mallocLong(1);
-                    int err = vkCreateXlibSurfaceKHR(data.instance, sci, null, pSurface);
-                    if (err != VK_SUCCESS) {
-                        throw new AWTException("Calling vkCreateXlibSurfaceKHR failed with error: " + err);
-                    }
+                LongBuffer pSurface = stack.mallocLong(1);
+                int result = vkCreateXlibSurfaceKHR(data.instance, pCreateInfo, null, pSurface);
 
+                // Possible VkResult codes returned
+                if (result == VK_SUCCESS) {
                     return pSurface.get(0);
-                } finally {
-                    JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
                 }
-            } finally {
-                JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
+                if (result == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                    throw new AWTException("Failed to create a Vulkan surface: out of host memory.");
+                }
+                if (result == VK_ERROR_OUT_OF_DEVICE_MEMORY) {
+                    throw new AWTException("Failed to create a Vulkan surface: out of device memory.");
+                }
+
+                // Error unknown to the implementation
+                if (result == VK_ERROR_UNKNOWN) {
+                    throw new AWTException("An unknown error occurred. This may be because of an invalid input, " +
+                            "or because the Vulkan implementation has a bug.");
+                }
+
+                // Unknown error not included in this list
+                throw new AWTException("Calling vkCreateWin32SurfaceKHR failed with unknown Vulkan error: " + result);
             }
-        } finally {
-            JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
         }
     }
 

--- a/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
@@ -25,7 +25,7 @@ public class PlatformX11VKCanvas implements PlatformVKCanvas {
 
     @Override
     public long create(Canvas canvas, VKData data) throws AWTException {
-        try (AWT awt = AWT.create(canvas)) {
+        try (AWT awt = new AWT(canvas)) {
             try (MemoryStack stack = MemoryStack.stackPush()) {
                 JAWTX11DrawingSurfaceInfo dsiX11 = JAWTX11DrawingSurfaceInfo.create(awt.getPlatformInfo());
 

--- a/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
@@ -20,9 +20,6 @@ import static org.lwjgl.vulkan.VK10.*;
  */
 public class PlatformX11VKCanvas implements PlatformVKCanvas {
 
-    // 3.2.3 does not include the newest VkResult code
-    private static final int VK_ERROR_UNKNOWN = -13;
-
     @Override
     public long create(Canvas canvas, VKData data) throws AWTException {
         try (AWT awt = new AWT(canvas)) {
@@ -30,7 +27,7 @@ public class PlatformX11VKCanvas implements PlatformVKCanvas {
                 JAWTX11DrawingSurfaceInfo dsiX11 = JAWTX11DrawingSurfaceInfo.create(awt.getPlatformInfo());
 
                 VkXlibSurfaceCreateInfoKHR pCreateInfo = VkXlibSurfaceCreateInfoKHR
-                        .callocStack(stack)
+                        .calloc(stack)
                         .dpy(dsiX11.display())
                         .window(dsiX11.drawable());
 

--- a/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
@@ -34,25 +34,25 @@ public class PlatformX11VKCanvas implements PlatformVKCanvas {
                 LongBuffer pSurface = stack.mallocLong(1);
                 int result = vkCreateXlibSurfaceKHR(data.instance, pCreateInfo, null, pSurface);
 
-                // Possible VkResult codes returned
-                if (result == VK_SUCCESS) {
-                    return pSurface.get(0);
-                }
-                if (result == VK_ERROR_OUT_OF_HOST_MEMORY) {
-                    throw new AWTException("Failed to create a Vulkan surface: out of host memory.");
-                }
-                if (result == VK_ERROR_OUT_OF_DEVICE_MEMORY) {
-                    throw new AWTException("Failed to create a Vulkan surface: out of device memory.");
-                }
+                switch (result) {
+                    case VK_SUCCESS:
+                        return pSurface.get(0);
 
-                // Error unknown to the implementation
-                if (result == VK_ERROR_UNKNOWN) {
-                    throw new AWTException("An unknown error occurred. This may be because of an invalid input, " +
-                            "or because the Vulkan implementation has a bug.");
-                }
+                    // Possible VkResult codes returned
+                    case VK_ERROR_OUT_OF_HOST_MEMORY:
+                        throw new AWTException("Failed to create a Vulkan surface: a host memory allocation has failed.");
+                    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+                        throw new AWTException("Failed to create a Vulkan surface: a device memory allocation has failed.");
 
-                // Unknown error not included in this list
-                throw new AWTException("Calling vkCreateWin32SurfaceKHR failed with unknown Vulkan error: " + result);
+                    // Error unknown to the implementation
+                    case VK_ERROR_UNKNOWN:
+                        throw new AWTException("An unknown error has occurred;" +
+                                " either the application has provided invalid input, or an implementation failure has occurred.");
+
+                    // Unknown error not included in this list
+                    default:
+                        throw new AWTException("Calling vkCreateXlibSurfaceKHR failed with unknown Vulkan error: " + result);
+                }
             }
         }
     }

--- a/test/org/lwjgl/vulkan/awt/SimpleDemo.java
+++ b/test/org/lwjgl/vulkan/awt/SimpleDemo.java
@@ -35,7 +35,8 @@ public class SimpleDemo {
      */
     private static VkInstance createInstance() {
         try (MemoryStack stack = MemoryStack.stackPush()) {
-            VkApplicationInfo appInfo = VkApplicationInfo.callocStack(stack)
+            VkApplicationInfo appInfo = VkApplicationInfo
+                    .calloc(stack)
                     .sType(VK_STRUCTURE_TYPE_APPLICATION_INFO)
                     .pApplicationName(stack.UTF8("AWT Vulkan Demo"))
                     .pEngineName(stack.UTF8(""))
@@ -68,7 +69,8 @@ public class SimpleDemo {
             ppEnabledExtensionNames.put(VK_KHR_SURFACE_EXTENSION);
             ppEnabledExtensionNames.put(VK_KHR_OS_SURFACE_EXTENSION);
             ppEnabledExtensionNames.flip();
-            VkInstanceCreateInfo pCreateInfo = VkInstanceCreateInfo.callocStack(stack)
+            VkInstanceCreateInfo pCreateInfo = VkInstanceCreateInfo
+                    .calloc(stack)
                     .sType(VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
                     .pNext(0L)
                     .pApplicationInfo(appInfo);


### PR DESCRIPTION
1. Created new helper class
    1. Cleaner code
    2. Reduce duplication
2. Documentation
    1. Document Apple APIs
    2. Add public-facing javadoc
3. Better error handling
    1. Null checks
    2. Descriptive exceptions
4. Completely backwards compatible; no breaking changes

New interface for getting the pointer to platform-specific structs. Use a try-with-resources block to get the data (or don't, and manually `free()` it):

```java
try (AWT awt = new AWT) {
    long ptr = awt.getPlatformInfo();

    // ...
}
```