### PR TITLE
Update to LWJGL 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		</developer>
 	</developers>
 	<properties>
-		<lwjgl.version>3.2.3</lwjgl.version>
+		<lwjgl.version>3.3.0</lwjgl.version>
 		<junit.version>5.7.0</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
@@ -683,7 +683,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
             effective.majorVersion = version.major;
             effective.minorVersion = version.minor;
         } else if (attribs.api == API.GLES) {
-            APIVersion version = APIUtil.apiParseVersion(MemoryUtil.memUTF8(Checks.check(JNI.callP(GL11.GL_VERSION, getString))), "OpenGL ES");
+            APIVersion version = APIUtil.apiParseVersion(MemoryUtil.memUTF8(Checks.check(JNI.callP(GL11.GL_VERSION, getString))));
             effective.majorVersion = version.major;
             effective.minorVersion = version.minor;
         }


### PR DESCRIPTION
LWJGL 3.3.0 brings libffi, which should allow us to get rid of the native lib for macOS.