### PR TITLE
Ignore scaling transforms when resizing a orphan AWTGLCanvas.

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -40,8 +40,12 @@ public abstract class AWTGLCanvas extends Canvas {
     private final ComponentListener listener = new ComponentAdapter() {
         @Override
         public void componentResized(ComponentEvent e) {
-            java.awt.geom.AffineTransform t = AWTGLCanvas.this.getGraphicsConfiguration().getDefaultTransform();
-            float sx = (float) t.getScaleX(), sy = (float) t.getScaleY();
+	    float sx = 1, sy = 1;
+	    GraphicsConfiguration gconf = AWTGLCanvas.this.getGraphicsConfiguration();
+	    if(gconf != null) {
+		java.awt.geom.AffineTransform t = gconf.getDefaultTransform();
+		sx = (float) t.getScaleX(); sy = (float) t.getScaleY();
+	    }
             AWTGLCanvas.this.framebufferWidth = (int) (getWidth() * sx);
             AWTGLCanvas.this.framebufferHeight = (int) (getHeight() * sy);
         }


### PR DESCRIPTION
Before the canvas has been added to a parent, its GraphicsConfiguration is null, causing the resize event from eg. a setSize to throw an exception on stderr from the AWT thread.

I'll admit I'm not sure how the size if the size is set correctly with scaling this way (I don't have a system with system UI scaling to test on), and/or whether a resize event is generated when the canvas is added, nor am I sure whether you would argue that I should just set the size of the canvas after I've added it (I currently call `setSize` in the constructor of my `AWTGLCanvas` subclass). I guess I'm saying "feel free to comment", but this is my naïve suggestion.