### PR TITLE
Make screenshot tests work with tiling window managers.

### DIFF
--- a/test/org/lwjgl/opengl/awt/CompareScreenshotTest.java
+++ b/test/org/lwjgl/opengl/awt/CompareScreenshotTest.java
@@ -62,6 +62,7 @@ public class CompareScreenshotTest {
     void setup(TestInfo testInfo) {
         frame = new JFrame(testInfo.getDisplayName());
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+	frame.setResizable(false);
     }
 
     @AfterEach
@@ -217,6 +218,7 @@ public class CompareScreenshotTest {
         }}, BorderLayout.WEST);
 
         frame.pack();
+	frame.setResizable(false);
         frame.setVisible(true);
         frame.transferFocus();
 


### PR DESCRIPTION
On some window managers, notably tiling ones, a resizable window will automatically be resized from its default size, which makes the screenshot comparison tests fail. Making the `JFrame` non-resizable fixes the issue.