### PR TITLE
Add setSwapInterval operation on AWTGLCanvas

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -151,6 +151,10 @@ public abstract class AWTGLCanvas extends Canvas {
         platformCanvas.swapBuffers();
     }
     
+    public final void setSwapInterval(int interval) {
+        platformCanvas.setSwapInterval(interval);
+    }
+
     /**
      * Returns Graphics object that ignores {@link Graphics#clearRect(int, int, int, int)}
      * calls.

--- a/src/org/lwjgl/opengl/awt/PlatformGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformGLCanvas.java
@@ -14,6 +14,7 @@ public interface PlatformGLCanvas {
     boolean makeCurrent(long context);
     boolean isCurrent(long context);
     boolean swapBuffers();
+    void setSwapInterval(int interval);
     boolean delayBeforeSwapNV(float seconds);
     void lock() throws AWTException;
     void unlock() throws AWTException;

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -336,6 +336,11 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     }
 
     @Override
+    public void setSwapInterval(int interval) {
+	/* XXX: How does this work on MacOS? */
+    }
+
+    @Override
     public boolean deleteContext(long context) {
         // frees created NSOpenGLView
         invokePPP(view, sel_getUid("removeFromSuperviewWithoutNeedingDisplay"), objc_msgSend);


### PR DESCRIPTION
Being able to turn VSync on and off at runtime is nice.

It's not supported on MacOS yet, because I can't quite figure out how MacOS does this.