### PR TITLE
Extend the AWTGLCanvas context creation interface to allow trying different parameters.

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -32,9 +32,9 @@ public abstract class AWTGLCanvas extends Canvas {
         }
     }
 
-    protected long context;
+    protected ContextData context;
     protected final GLData data;
-    protected final GLData effective = new GLData();
+    protected GLData effective = new GLData();
     protected boolean initCalled;
     private int framebufferWidth, framebufferHeight;
     private final ComponentListener listener = new ComponentAdapter() {
@@ -51,7 +51,7 @@ public abstract class AWTGLCanvas extends Canvas {
     public void removeNotify() {
         super.removeNotify();
         // prepare for a possible re-adding
-        context = 0;
+        context = null;
         initCalled = false;
         disposeCanvas();
     }
@@ -73,10 +73,19 @@ public abstract class AWTGLCanvas extends Canvas {
         this(new GLData());
     }
 
+    protected ContextData createContext(GLData data) throws AWTException {
+	return platformCanvas.create(this, data);
+    }
+
+    protected ContextData createContext() throws AWTException {
+	return(createContext(data));
+    }
+
     protected void beforeRender() {
-        if (context == 0L) {
+        if (context == null) {
             try {
-                context = platformCanvas.create(this, data, effective);
+                context = createContext();
+		effective = context.caps;
             } catch (AWTException e) {
                 throw new RuntimeException("Exception while creating the OpenGL context", e);
             }
@@ -86,7 +95,7 @@ public abstract class AWTGLCanvas extends Canvas {
         } catch (AWTException e) {
             throw new RuntimeException("Failed to lock Canvas", e);
         }
-        platformCanvas.makeCurrent(context);
+        platformCanvas.makeCurrent(context.ctx);
     }
 
     protected void afterRender() {

--- a/src/org/lwjgl/opengl/awt/ContextData.java
+++ b/src/org/lwjgl/opengl/awt/ContextData.java
@@ -1,0 +1,11 @@
+package org.lwjgl.opengl.awt;
+
+public class ContextData {
+    public long ctx;
+    public GLData caps;
+
+    public ContextData(long ctx, GLData caps) {
+	this.ctx = ctx;
+	this.caps = caps;
+    }
+}

--- a/src/org/lwjgl/opengl/awt/PlatformGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformGLCanvas.java
@@ -9,8 +9,8 @@ import java.awt.Canvas;
  * @author Kai Burjack
  */
 public interface PlatformGLCanvas {
-    long create(Canvas canvas, GLData data, GLData effective) throws AWTException;
-    boolean deleteContext(long context);
+    ContextData create(Canvas canvas, GLData data) throws AWTException;
+    boolean deleteContext(ContextData context);
     boolean makeCurrent(long context);
     boolean isCurrent(long context);
     boolean swapBuffers();

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -93,7 +93,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     private int height;
 
     @Override
-    public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
+    public ContextData create(Canvas canvas, GLData attribs) throws AWTException {
         this.ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         canvas.addHierarchyListener(e -> {
             // if the canvas, or a parent component is hidden/shown, we must update the hidden state of the layer
@@ -202,7 +202,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                     view = createNSOpenGLView(dsi.platformInfo(), pixelFormat, dsi.bounds().x(), dsi.bounds().y(), width, height);
                     MacOSX.caFlush();
                     long openGLContext = invokePPP(view, sel_getUid("openGLContext"), objc_msgSend);
-                    return invokePPP(openGLContext, sel_getUid("CGLContextObj"), objc_msgSend);
+                    return new ContextData(invokePPP(openGLContext, sel_getUid("CGLContextObj"), objc_msgSend), new GLData());
                 } finally {
                     JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
                 }
@@ -336,7 +336,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     }
 
     @Override
-    public boolean deleteContext(long context) {
+    public boolean deleteContext(ContextData context) {
         // frees created NSOpenGLView
         invokePPP(view, sel_getUid("removeFromSuperviewWithoutNeedingDisplay"), objc_msgSend);
         invokePPP(view, sel_getUid("clearGLContext"), objc_msgSend);


### PR DESCRIPTION
My particular use-case for this is going through different OpenGL versions and see which one sticks.

It introduces the `ContextData` class to allow passing the context back through an override of the `createContext` method in a way that can be extended into the future, and also puts the effective `GLData` in there.

It does perhaps to some extent call into question the role of the `data` and `effective` fields in `AWTGLCanvas`, but I wanted this change to be backward compatible, for obvious reasons.