### PR TITLE
Fix struct type for X11 surface creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		</developer>
 	</developers>
 	<properties>
-		<lwjgl.version>3.3.1</lwjgl.version>
+		<lwjgl.version>3.3.3</lwjgl.version>
 		<junit.version>5.8.2</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
@@ -47,6 +47,7 @@ public class PlatformX11VKCanvas implements PlatformVKCanvas {
 
                 VkXlibSurfaceCreateInfoKHR pCreateInfo = VkXlibSurfaceCreateInfoKHR
                         .calloc(stack)
+                        .sType(VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR)
                         .dpy(dsiX11.display())
                         .window(dsiX11.drawable());
 


### PR DESCRIPTION
This PR fixes an issue where the structure type for VkXlibSurfaceCreateInfoKHR seems to have gotten lost.