### PR TITLE
Fix crash on macOS due to setLayer being executed not on AppKit's main thread (fixes #60)

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -248,9 +248,11 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                 objc_msgSend);
 
         // set layer on JAWTSurfaceLayers object
-        JNI.callPPPV(platformInfo,
+        JNI.callPPPPV(platformInfo,
+                ObjCRuntime.sel_getUid("performSelectorOnMainThread:withObject:waitUntilDone:"),
                 ObjCRuntime.sel_getUid("setLayer:"),
                 openglViewLayer,
+                ObjCRuntime.YES,
                 objc_msgSend);
 
         return view;


### PR DESCRIPTION
Execute `[platformInfo setLayer:openglViewLayer]` on AppKit's main thread to fix crash on macOS.
Fixes #60

<img width="712" alt="OpenGL+AWT" src="https://github.com/user-attachments/assets/fd3b3950-beb5-4043-ab12-09dd9ddcf7a1">