### PR TITLE
fix: AWTGLCanvas gives error when activating sRGB

### DIFF
--- a/src/org/lwjgl/opengl/awt/GLData.java
+++ b/src/org/lwjgl/opengl/awt/GLData.java
@@ -124,8 +124,9 @@ public class GLData {
      * Whether to use sRGB color space.
      */
     public boolean sRGB;
+    
     /**
-     * 
+     * <b>For internal use only<b>, used to determine the sRGB extension to use
      */
     public SRGB buffer_sRGB = SRGB.EXT_sRGB;
     /**

--- a/src/org/lwjgl/opengl/awt/GLData.java
+++ b/src/org/lwjgl/opengl/awt/GLData.java
@@ -126,7 +126,7 @@ public class GLData {
     public boolean sRGB;
     
     /**
-     * <b>For internal use only<b>, used to determine the sRGB extension to use
+     * <b>For internal use only</b>, used to determine the sRGB extension to use
      */
     public SRGB buffer_sRGB = SRGB.EXT_sRGB;
     /**

--- a/src/org/lwjgl/opengl/awt/GLData.java
+++ b/src/org/lwjgl/opengl/awt/GLData.java
@@ -87,6 +87,10 @@ public class GLData {
     public static enum ReleaseBehavior {
         NONE, FLUSH;
     }
+    
+    public static enum SRGB {
+        EXT_sRGB, ARB_sRGB
+    }
 
     /**
      * The major GL context version to use. It defaults to 0 for "not specified".
@@ -120,6 +124,10 @@ public class GLData {
      * Whether to use sRGB color space.
      */
     public boolean sRGB;
+    /**
+     * 
+     */
+    public SRGB buffer_sRGB = SRGB.EXT_sRGB;
     /**
      * Whether to use a floating point pixel format.
      */

--- a/src/org/lwjgl/opengl/awt/GLData.java
+++ b/src/org/lwjgl/opengl/awt/GLData.java
@@ -87,10 +87,6 @@ public class GLData {
     public static enum ReleaseBehavior {
         NONE, FLUSH;
     }
-    
-    public static enum SRGB {
-        EXT_sRGB, ARB_sRGB
-    }
 
     /**
      * The major GL context version to use. It defaults to 0 for "not specified".
@@ -123,12 +119,11 @@ public class GLData {
     /**
      * Whether to use sRGB color space.
      */
-    public boolean sRGB;
-    
+    public boolean sRGB;    
     /**
-     * <b>For internal use only</b>, used to determine the sRGB extension to use
+     * Used to determine the sRGB extension to use
      */
-    public SRGB buffer_sRGB = SRGB.EXT_sRGB;
+    boolean extBuffer_sRGB = true;
     /**
      * Whether to use a floating point pixel format.
      */

--- a/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
@@ -111,11 +111,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
         if (attribs.accumRedSize > 0 || attribs.accumGreenSize > 0 || attribs.accumBlueSize > 0 || attribs.accumAlphaSize > 0)
             ib.put(WGL_ACCUM_BITS_ARB).put(attribs.accumRedSize + attribs.accumGreenSize + attribs.accumBlueSize + attribs.accumAlphaSize);
         if (attribs.sRGB)
-            if (attribs.buffer_sRGB == GLData.SRGB.EXT_sRGB) {
-                ib.put(WGL_FRAMEBUFFER_SRGB_CAPABLE_EXT).put(1);
-            } else {
-                ib.put(WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB).put(1);
-            }
+            ib.put(attribs.extBuffer_sRGB ? WGL_FRAMEBUFFER_SRGB_CAPABLE_EXT : WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB).put(1);
         if (attribs.samples > 0) {
             ib.put(WGL_SAMPLE_BUFFERS_ARB).put(1);
             ib.put(WGL_SAMPLES_ARB).put(attribs.samples);
@@ -442,11 +438,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
                     throw new AWTException("sRGB color space requested but WGL_EXT_framebuffer_sRGB is unavailable");
                 }
                 
-                if (has_WGL_ARB_framebuffer_sRGB) {
-                    attribs.buffer_sRGB = GLData.SRGB.ARB_sRGB;
-                } else {
-                    attribs.buffer_sRGB = GLData.SRGB.EXT_sRGB;
-                }
+                attribs.extBuffer_sRGB = has_WGL_EXT_framebuffer_sRGB;
             }
             if (attribs.pixelFormatFloat) {
                 // Check for WGL_ARB_pixel_format_float


### PR DESCRIPTION
This PR fixes issue #78, it seems that the extensions do not check for the possibility of the `WGL_ARB_framebuffer_sRGB` option (_ARB_ extension) and that throws an exception, I would like you to check that.