### PR TITLE
Fix native dependency scopes for Gradle consumers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl-opengl</artifactId>
 			<classifier>${lwjgl.natives}</classifier>
-			<optional>true</optional>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.lwjgl</groupId>
@@ -388,6 +388,7 @@
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl</artifactId>
 			<classifier>${lwjgl.natives}</classifier>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- TESTS -->


### PR DESCRIPTION
Marks native-classifier dependencies as test-only so `${lwjgl.natives}` no longer leaks into published runtime metadata.

Verified with a Gradle project consuming the locally published artifact.

Fixes #74
Fixes #83