### PR TITLE
Delete OpenGL contexts when disposing canvases

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -50,9 +50,6 @@ public abstract class AWTGLCanvas extends Canvas {
     @Override
     public void removeNotify() {
         super.removeNotify();
-        // prepare for a possible re-adding
-        context = 0;
-        initCalled = false;
         disposeCanvas();
     }
 
@@ -61,8 +58,23 @@ public abstract class AWTGLCanvas extends Canvas {
         super.addComponentListener(l);
     }
 
+    /**
+     * Deletes the OpenGL context and releases the platform drawing surface.
+     *
+     * <p>This method must not run concurrently with rendering. Applications that render on a dedicated thread should
+     * override it to arrange cleanup on that thread.</p>
+     */
     public void disposeCanvas() {
-        this.platformCanvas.dispose();
+        try {
+            if (context != 0L) {
+                platformCanvas.deleteContext(context);
+            }
+        } finally {
+            // prepare for a possible re-adding
+            context = 0L;
+            initCalled = false;
+            platformCanvas.dispose();
+        }
     }
     protected AWTGLCanvas(GLData data) {
         this.data = data;

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -131,7 +131,8 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	}
 
 	public boolean deleteContext(long context) {
-		return false;
+		glXDestroyContext(display, context);
+		return true;
 	}
 
 	public boolean makeCurrent(long context) {

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -90,6 +90,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     public JAWTDrawingSurface ds;
     private Canvas canvas;
     private long view;
+    private boolean hierarchyListenerAdded;
     private int width;
     private int height;
 
@@ -97,13 +98,16 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
         this.ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         this.canvas = canvas;
-        canvas.addHierarchyListener(e -> {
-            // if the canvas, or a parent component is hidden/shown, we must update the hidden state of the layer
-            if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) > 0) {
-                long layer = invokePPP(view, sel_getUid("layer"), objc_msgSend);
-                setLayerHiddenOnMainThread(layer, !e.getChanged().isShowing());
-            }
-        });
+        if (!hierarchyListenerAdded) {
+            canvas.addHierarchyListener(e -> {
+                // if the canvas, or a parent component is hidden/shown, we must update the hidden state of the layer
+                if (view != 0L && (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) > 0) {
+                    long layer = invokePPP(view, sel_getUid("layer"), objc_msgSend);
+                    setLayerHiddenOnMainThread(layer, !e.getChanged().isShowing());
+                }
+            });
+            hierarchyListenerAdded = true;
+        }
         JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         try {
             int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
@@ -441,7 +445,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         invokePPP(view, sel_getUid("removeFromSuperviewWithoutNeedingDisplay"), objc_msgSend);
         invokePPP(view, sel_getUid("clearGLContext"), objc_msgSend);
         invokePPP(view, sel_getUid("release"), objc_msgSend);
-        return false;
+        view = 0L;
+        return true;
     }
 
     @Override

--- a/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
@@ -1,0 +1,121 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.AWTException;
+import java.awt.Canvas;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AWTGLCanvasLifecycleTest {
+
+    @Test
+    void disposeCanvasDeletesContextBeforeDrawingSurface() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        TestCanvas canvas = new TestCanvas(platform);
+        canvas.context = 42L;
+        canvas.initCalled = true;
+
+        canvas.disposeCanvas();
+
+        assertEquals(Arrays.asList("delete:42", "dispose"), platform.calls);
+        assertEquals(0L, canvas.context);
+        assertFalse(canvas.initCalled);
+    }
+
+    @Test
+    void disposeCanvasStillResetsStateWhenContextDeletionFails() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.deleteFailure = new IllegalStateException("delete failed");
+        TestCanvas canvas = new TestCanvas(platform);
+        canvas.context = 42L;
+        canvas.initCalled = true;
+
+        assertThrows(IllegalStateException.class, canvas::disposeCanvas);
+
+        assertEquals(Arrays.asList("delete:42", "dispose"), platform.calls);
+        assertEquals(0L, canvas.context);
+        assertFalse(canvas.initCalled);
+    }
+
+    @Test
+    void disposeCanvasSkipsDeletionWithoutAContext() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        TestCanvas canvas = new TestCanvas(platform);
+
+        canvas.disposeCanvas();
+
+        assertEquals(Arrays.asList("dispose"), platform.calls);
+    }
+
+    private static class TestCanvas extends AWTGLCanvas {
+        TestCanvas(PlatformGLCanvas platformCanvas) {
+            this.platformCanvas = platformCanvas;
+        }
+
+        @Override
+        public void initGL() {
+        }
+
+        @Override
+        public void paintGL() {
+        }
+    }
+
+    private static class RecordingPlatformCanvas implements PlatformGLCanvas {
+        final List<String> calls = new ArrayList<>();
+        RuntimeException deleteFailure;
+
+        @Override
+        public long create(Canvas canvas, GLData data, GLData effective) {
+            return 42L;
+        }
+
+        @Override
+        public boolean deleteContext(long context) {
+            calls.add("delete:" + context);
+            if (deleteFailure != null) {
+                throw deleteFailure;
+            }
+            return true;
+        }
+
+        @Override
+        public boolean makeCurrent(long context) {
+            return true;
+        }
+
+        @Override
+        public boolean isCurrent(long context) {
+            return false;
+        }
+
+        @Override
+        public boolean swapBuffers() {
+            return true;
+        }
+
+        @Override
+        public boolean delayBeforeSwapNV(float seconds) {
+            return false;
+        }
+
+        @Override
+        public void lock() throws AWTException {
+        }
+
+        @Override
+        public void unlock() throws AWTException {
+        }
+
+        @Override
+        public void dispose() {
+            calls.add("dispose");
+        }
+    }
+}


### PR DESCRIPTION
`AWTGLCanvas.removeNotify()` previously cleared the context handle without calling the platform’s `deleteContext()` implementation, leaking the native context.

This change makes `disposeCanvas()` delete the context before releasing the drawing surface. It also:

- Implements the missing Linux context deletion.
- Safely resets the macOS view during disposal.
- Avoids accumulating macOS hierarchy listeners after re-adding a canvas.
- Adds lifecycle tests covering deletion order and failure cleanup.

Verified on Java 8 and newer, including a native macOS remove/re-add test.

Fixes #41
