### PR TITLE
Avoid Robot screen capture in screenshot tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,11 +88,7 @@ jobs:
           path: 'target/*.png'
   test-macos:
     name: Test on macOS
-    # macos-15 (Sequoia) shows a "bypass window picker" privacy dialog whenever
-    # java.awt.Robot.createScreenCapture is invoked, which contaminates the
-    # screenshot-comparison tests. Stay on macos-14 until the tests are
-    # refactored to not rely on Robot screen capture.
-    runs-on: macos-14
+    runs-on: macos-latest
     timeout-minutes: 20
     permissions:
       contents: read

--- a/test/org/lwjgl/opengl/awt/CompareScreenshotTest.java
+++ b/test/org/lwjgl/opengl/awt/CompareScreenshotTest.java
@@ -8,25 +8,25 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
-import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.Graphics2D;
 import java.awt.Insets;
-import java.awt.Rectangle;
-import java.awt.Robot;
+import java.awt.Point;
 import java.awt.Window;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import com.github.romankh3.image.comparison.ImageComparison;
+import com.github.romankh3.image.comparison.model.ImageComparisonState;
+import org.lwjgl.BufferUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,14 +35,41 @@ import org.junit.jupiter.api.TestInfo;
 
 import static org.lwjgl.opengl.GL.createCapabilities;
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DRAW_BUFFER;
+import static org.lwjgl.opengl.GL11.GL_PACK_ALIGNMENT;
 import static org.lwjgl.opengl.GL11.GL_QUADS;
+import static org.lwjgl.opengl.GL11.GL_READ_BUFFER;
+import static org.lwjgl.opengl.GL11.GL_RGBA;
+import static org.lwjgl.opengl.GL11.GL_RGBA8;
+import static org.lwjgl.opengl.GL11.GL_UNSIGNED_BYTE;
 import static org.lwjgl.opengl.GL11.glBegin;
 import static org.lwjgl.opengl.GL11.glClear;
 import static org.lwjgl.opengl.GL11.glClearColor;
 import static org.lwjgl.opengl.GL11.glColor3f;
+import static org.lwjgl.opengl.GL11.glDrawBuffer;
 import static org.lwjgl.opengl.GL11.glEnd;
+import static org.lwjgl.opengl.GL11.glFinish;
+import static org.lwjgl.opengl.GL11.glGetInteger;
+import static org.lwjgl.opengl.GL11.glPixelStorei;
+import static org.lwjgl.opengl.GL11.glReadBuffer;
+import static org.lwjgl.opengl.GL11.glReadPixels;
 import static org.lwjgl.opengl.GL11.glVertex2f;
 import static org.lwjgl.opengl.GL11.glViewport;
+import static org.lwjgl.opengl.EXTFramebufferObject.GL_COLOR_ATTACHMENT0_EXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.GL_FRAMEBUFFER_BINDING_EXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.GL_FRAMEBUFFER_COMPLETE_EXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.GL_FRAMEBUFFER_EXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.GL_RENDERBUFFER_BINDING_EXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.GL_RENDERBUFFER_EXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glBindFramebufferEXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glBindRenderbufferEXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glCheckFramebufferStatusEXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glDeleteFramebuffersEXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glDeleteRenderbuffersEXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glFramebufferRenderbufferEXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glGenFramebuffersEXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glGenRenderbuffersEXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glRenderbufferStorageEXT;
 
 public class CompareScreenshotTest {
 
@@ -59,237 +86,139 @@ public class CompareScreenshotTest {
     private JFrame frame;
 
     @BeforeEach
-    void setup(TestInfo testInfo) {
-        frame = new JFrame(testInfo.getDisplayName());
-        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+    void setup(TestInfo testInfo) throws InvocationTargetException, InterruptedException {
+        SwingUtilities.invokeAndWait(() -> {
+            frame = new JFrame(testInfo.getDisplayName());
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        });
     }
 
     @AfterEach
-    void tearDown() {
+    void tearDown() throws InvocationTargetException, InterruptedException {
         if (frame != null) {
-            frame.dispose();
+            JFrame frameToDispose = frame;
             frame = null;
+            SwingUtilities.invokeAndWait(frameToDispose::dispose);
         }
     }
 
     @Test
-    void canvasInContentPane(TestInfo testInfo) throws AWTException, IOException {
-        frame.setLayout(new BorderLayout());
-        GLData data = new GLData();
-        data.samples = 0;
-        data.swapInterval = 0;
-        AWTGLCanvas canvas = new DemoCanvas(data);
-        frame.add(canvas, BorderLayout.CENTER);
-        canvas.setPreferredSize(new Dimension(600, 600));
-
-        frame.add(new JPanel() {{
-            setBackground(Color.BLUE);
-        }}, BorderLayout.NORTH);
-        frame.add(new JPanel() {{
-            setBackground(Color.RED);
-        }}, BorderLayout.SOUTH);
-        frame.add(new JPanel() {{
-            setBackground(Color.GREEN);
-        }}, BorderLayout.EAST);
-        frame.add(new JPanel() {{
-            setBackground(Color.YELLOW);
-        }}, BorderLayout.WEST);
-
-        frame.pack();
-        frame.setVisible(true);
-        frame.transferFocus();
-
+    void canvasInContentPane(TestInfo testInfo) throws IOException, InvocationTargetException, InterruptedException {
+        DemoCanvas canvas = showSingleCanvas();
         compareWithScreenshot(testInfo, frame, canvas);
     }
 
     @Test
-    void canvasInSplitPane(TestInfo testInfo) throws AWTException, IOException {
-        frame.setLayout(new BorderLayout());
-        GLData data = new GLData();
-        data.samples = 0;
-        data.swapInterval = 0;
-
-        JSplitPane vert1 = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
-        JSplitPane vert2 = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
-        JSplitPane horiz = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
-        horiz.setLeftComponent(vert1);
-        horiz.setRightComponent(vert2);
-
-        DemoCanvas canvas1 = new DemoCanvas(data);
-        canvas1.setPreferredSize(new Dimension(200, 200));
-        vert1.setTopComponent(canvas1);
-
-        DemoCanvas canvas2 = new DemoCanvas(data);
-        canvas2.setPreferredSize(new Dimension(200, 200));
-        vert1.setBottomComponent(canvas2);
-
-        DemoCanvas canvas3 = new DemoCanvas(data);
-        canvas3.setPreferredSize(new Dimension(200, 200));
-        vert2.setTopComponent(canvas3);
-
-        DemoCanvas canvas4 = new DemoCanvas(data);
-        canvas4.setPreferredSize(new Dimension(200, 200));
-        vert2.setBottomComponent(canvas4);
-
-        frame.add(horiz, BorderLayout.CENTER);
-
-        frame.add(new JPanel() {{
-            setBackground(Color.BLUE);
-        }}, BorderLayout.NORTH);
-        frame.add(new JPanel() {{
-            setBackground(Color.RED);
-        }}, BorderLayout.SOUTH);
-        frame.add(new JPanel() {{
-            setBackground(Color.GREEN);
-        }}, BorderLayout.EAST);
-        frame.add(new JPanel() {{
-            setBackground(Color.YELLOW);
-        }}, BorderLayout.WEST);
-
-        frame.pack();
-        frame.setVisible(true);
-        frame.transferFocus();
-
-        compareWithScreenshot(testInfo, frame, canvas1, canvas2, canvas3, canvas4);
+    void canvasInSplitPane(TestInfo testInfo) throws IOException, InvocationTargetException, InterruptedException {
+        DemoCanvas[] canvases = showSplitCanvases();
+        compareWithScreenshot(testInfo, frame, canvases);
     }
 
     @Test
-    void reAddCanvas(TestInfo testInfo) throws AWTException, IOException, InvocationTargetException, InterruptedException {
-        frame.setLayout(new BorderLayout());
-        GLData data = new GLData();
-        data.samples = 0;
-        data.swapInterval = 0;
-        AWTGLCanvas canvas = new DemoCanvas(data);
-        frame.add(canvas, BorderLayout.CENTER);
-        canvas.setPreferredSize(new Dimension(600, 600));
-
-        frame.add(new JPanel() {{
-            setBackground(Color.BLUE);
-        }}, BorderLayout.NORTH);
-        frame.add(new JPanel() {{
-            setBackground(Color.RED);
-        }}, BorderLayout.SOUTH);
-        frame.add(new JPanel() {{
-            setBackground(Color.GREEN);
-        }}, BorderLayout.EAST);
-        frame.add(new JPanel() {{
-            setBackground(Color.YELLOW);
-        }}, BorderLayout.WEST);
-
-        frame.pack();
-        frame.setVisible(true);
-        frame.transferFocus();
+    void reAddCanvas(TestInfo testInfo) throws IOException, InvocationTargetException, InterruptedException {
+        DemoCanvas canvas = showSingleCanvas();
 
         // make sure the underlying OpenGL Context is created
         SwingUtilities.invokeAndWait(canvas::render);
 
         // remove and re-add
-        frame.remove(canvas);
-        frame.add(canvas, BorderLayout.CENTER);
-        frame.pack();
+        SwingUtilities.invokeAndWait(() -> {
+            frame.remove(canvas);
+            frame.add(canvas, BorderLayout.CENTER);
+            frame.pack();
+        });
 
         compareWithScreenshot(testInfo, frame, canvas);
     }
 
     @Test
-    void hideAndShowCanvas(TestInfo testInfo) throws AWTException, IOException, InvocationTargetException, InterruptedException {
-        JFrame frame = new JFrame(testInfo.getDisplayName());
-        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-        frame.setLayout(new BorderLayout());
-        GLData data = new GLData();
-        data.samples = 0;
-        data.swapInterval = 0;
-        AWTGLCanvas canvas = new DemoCanvas(data);
-        frame.add(canvas, BorderLayout.CENTER);
-        canvas.setPreferredSize(new Dimension(600, 600));
-
-        frame.add(new JPanel() {{
-            setBackground(Color.BLUE);
-        }}, BorderLayout.NORTH);
-        frame.add(new JPanel() {{
-            setBackground(Color.RED);
-        }}, BorderLayout.SOUTH);
-        frame.add(new JPanel() {{
-            setBackground(Color.GREEN);
-        }}, BorderLayout.EAST);
-        frame.add(new JPanel() {{
-            setBackground(Color.YELLOW);
-        }}, BorderLayout.WEST);
-
-        frame.pack();
-        frame.setVisible(true);
-        frame.transferFocus();
+    void hideAndShowCanvas(TestInfo testInfo) throws IOException, InvocationTargetException, InterruptedException {
+        DemoCanvas canvas = showSingleCanvas();
 
         // make sure the underlying OpenGL Context is created
         SwingUtilities.invokeAndWait(canvas::render);
-
-        frame.pack();
+        SwingUtilities.invokeAndWait(frame::pack);
 
         compareWithScreenshot(testInfo, frame, canvas);
 
         // hide
-        canvas.setVisible(false);
+        SwingUtilities.invokeAndWait(() -> canvas.setVisible(false));
         compareWithScreenshot(testInfo, frame);
 
         // show
-        canvas.setVisible(true);
+        SwingUtilities.invokeAndWait(() -> canvas.setVisible(true));
         compareWithScreenshot(testInfo, frame, canvas);
     }
 
-    private void compareWithScreenshot(TestInfo testInfo, Window window, AWTGLCanvas... canvases) throws AWTException, IOException {
-        AtomicInteger renderCount = new AtomicInteger(0);
+    private DemoCanvas showSingleCanvas() throws InvocationTargetException, InterruptedException {
+        DemoCanvas[] result = new DemoCanvas[1];
+        SwingUtilities.invokeAndWait(() -> {
+            frame.setLayout(new BorderLayout());
+            DemoCanvas canvas = new DemoCanvas(createGLData());
+            canvas.setPreferredSize(new Dimension(600, 600));
+            frame.add(canvas, BorderLayout.CENTER);
+            addBorderPanels();
+            showFrame();
+            result[0] = canvas;
+        });
+        return result[0];
+    }
 
-        AtomicReference<Exception> renderException = new AtomicReference<>();
+    private DemoCanvas[] showSplitCanvases() throws InvocationTargetException, InterruptedException {
+        DemoCanvas[] canvases = new DemoCanvas[4];
+        SwingUtilities.invokeAndWait(() -> {
+            frame.setLayout(new BorderLayout());
+            JSplitPane topAndBottomLeft = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
+            JSplitPane topAndBottomRight = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
+            JSplitPane leftAndRight = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+            leftAndRight.setLeftComponent(topAndBottomLeft);
+            leftAndRight.setRightComponent(topAndBottomRight);
 
-        Runnable renderLoop = new Runnable() {
-            public void run() {
-                for (AWTGLCanvas canvas : canvases) {
-                    if (!canvas.isValid())
-                        return;
-                    if (renderException.get() != null) {
-                        return;
-                    }
-                    renderCount.incrementAndGet();
-                    try {
-                        if (renderCount.get() < 10) {
-                            canvas.render();
-                        }
-                    } catch (Exception e) {
-                        renderException.set(e);
-                    }
-                }
-                SwingUtilities.invokeLater(this);
+            GLData data = createGLData();
+            for (int i = 0; i < canvases.length; i++) {
+                canvases[i] = new DemoCanvas(data);
+                canvases[i].setPreferredSize(new Dimension(200, 200));
             }
-        };
-        SwingUtilities.invokeLater(renderLoop);
+            topAndBottomLeft.setTopComponent(canvases[0]);
+            topAndBottomLeft.setBottomComponent(canvases[1]);
+            topAndBottomRight.setTopComponent(canvases[2]);
+            topAndBottomRight.setBottomComponent(canvases[3]);
 
-        long startTime = System.currentTimeMillis();
+            frame.add(leftAndRight, BorderLayout.CENTER);
+            addBorderPanels();
+            showFrame();
+        });
+        return canvases;
+    }
 
-        // Wait until we definitely have been rendered, or a timeout of 20 seconds occurred
-        while (canvases.length > 0 && renderException.get() == null && renderCount.get() < 10 && System.currentTimeMillis() - startTime < 20_000) {
-            Thread.yield();
-        }
-        Robot rbt = new Robot();
+    private static GLData createGLData() {
+        GLData data = new GLData();
+        data.samples = 0;
+        data.swapInterval = 0;
+        return data;
+    }
 
-        // Calculate inner window area
-        Rectangle frameBounds = window.getBounds();
-        Insets insets = window.getInsets();
-        frameBounds.y += insets.top;
-        frameBounds.height -= (insets.top + insets.bottom);
-        frameBounds.x += insets.left;
-        frameBounds.width -= (insets.left + insets.right);
+    private void addBorderPanels() {
+        frame.add(createPanel(Color.BLUE), BorderLayout.NORTH);
+        frame.add(createPanel(Color.RED), BorderLayout.SOUTH);
+        frame.add(createPanel(Color.GREEN), BorderLayout.EAST);
+        frame.add(createPanel(Color.YELLOW), BorderLayout.WEST);
+    }
 
-        window.toFront();
-        BufferedImage background = rbt.createScreenCapture(frameBounds);
-        // Some Operating Systems have a window open/close animation, so we wait until the screenshot is stable
-        while (true) {
-            BufferedImage s = rbt.createScreenCapture(frameBounds);
-            if (new ImageComparison(background, s).compareImages().getDifferencePercent() == 0) {
-                break;
-            } else {
-                background = s;
-            }
-        }
+    private static JPanel createPanel(Color color) {
+        JPanel panel = new JPanel();
+        panel.setBackground(color);
+        return panel;
+    }
+
+    private void showFrame() {
+        frame.pack();
+        frame.setVisible(true);
+        frame.transferFocus();
+    }
+
+    private void compareWithScreenshot(TestInfo testInfo, Window window, AWTGLCanvas... canvases) throws IOException {
+        BufferedImage background = captureWindow(window, canvases);
 
         String screenShotSuffix = "";
         int screenShotIndex = screenShotIndexMap.compute(testInfo, (info, index) -> index == null ? 1 : index + 1);
@@ -303,11 +232,6 @@ public class CompareScreenshotTest {
                         testInfo.getTestClass().map(Class::getSimpleName).orElse("unknown") + "_" +
                         testInfo.getTestMethod().map(Method::getName).orElse("unknown") + screenShotSuffix + ".png"));
 
-        if (renderException.get() != null) {
-            renderException.get().printStackTrace();
-            throw new RuntimeException(renderException.get());
-        }
-
         BufferedImage expectedImage = ImageIO.read(getClass().getResource("/" + testInfo.getTestClass().map(Class::getSimpleName).orElse("unknown") + "_" +
                 testInfo.getTestMethod().map(Method::getName).orElse("unknown") + screenShotSuffix + ".png"));
 
@@ -319,14 +243,109 @@ public class CompareScreenshotTest {
 
         //Create ImageComparison object for it.
         ImageComparison imageComparison = new ImageComparison(expectedImage, background, resultDestination);
-        //Mac OS has round corners in the bottom, so we need to ignore a few pixels
+        // Mac OS has rounded window corners, so ignore a few pixels at the edges.
         imageComparison.setAllowingPercentOfDifferentPixels(0.02d);
-        Assertions.assertTrue(imageComparison.compareImages().getDifferencePercent() < 0.1f);
+        Assertions.assertEquals(
+                ImageComparisonState.MATCH,
+                imageComparison.compareImages().getImageComparisonState());
+    }
+
+    private BufferedImage captureWindow(Window window, AWTGLCanvas... canvases) throws IOException {
+        BufferedImage[] result = new BufferedImage[1];
+        Runnable capture = () -> {
+            Map<AWTGLCanvas, BufferedImage> canvasImages = new HashMap<>();
+            for (AWTGLCanvas canvas : canvases) {
+                if (!canvas.isValid()) {
+                    throw new IllegalStateException("Cannot capture an invalid OpenGL canvas");
+                }
+                canvasImages.put(canvas, ((DemoCanvas) canvas).renderAndCaptureFramebuffer());
+            }
+
+            Insets insets = window.getInsets();
+            int width = window.getWidth() - insets.left - insets.right;
+            int height = window.getHeight() - insets.top - insets.bottom;
+            BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+            Graphics2D graphics = image.createGraphics();
+            try {
+                graphics.translate(-insets.left, -insets.top);
+                window.printAll(graphics);
+                graphics.translate(insets.left, insets.top);
+
+                for (Map.Entry<AWTGLCanvas, BufferedImage> entry : canvasImages.entrySet()) {
+                    AWTGLCanvas canvas = entry.getKey();
+                    Point location = SwingUtilities.convertPoint(canvas, 0, 0, window);
+                    graphics.drawImage(entry.getValue(),
+                            location.x - insets.left,
+                            location.y - insets.top,
+                            canvas.getWidth(),
+                            canvas.getHeight(),
+                            null);
+                }
+            } finally {
+                graphics.dispose();
+            }
+            result[0] = image;
+        };
+
+        try {
+            if (SwingUtilities.isEventDispatchThread()) {
+                capture.run();
+            } else {
+                SwingUtilities.invokeAndWait(capture);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while capturing the test window", e);
+        } catch (InvocationTargetException e) {
+            throw new IOException("Failed to capture the test window", e.getCause());
+        }
+        return result[0];
+    }
+
+    private static BufferedImage readFramebuffer(int width, int height) {
+        ByteBuffer pixels = BufferUtils.createByteBuffer(width * height * 4);
+        glPixelStorei(GL_PACK_ALIGNMENT, 1);
+        glFinish();
+        glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < height; y++) {
+            int sourceY = height - y - 1;
+            for (int x = 0; x < width; x++) {
+                int offset = (sourceY * width + x) * 4;
+                int red = pixels.get(offset) & 0xFF;
+                int green = pixels.get(offset + 1) & 0xFF;
+                int blue = pixels.get(offset + 2) & 0xFF;
+                image.setRGB(x, y, (red << 16) | (green << 8) | blue);
+            }
+        }
+        return image;
     }
 
     private static class DemoCanvas extends AWTGLCanvas {
+        private boolean captureRequested;
+        private BufferedImage framebufferImage;
+
         public DemoCanvas(GLData data) {
             super(data);
+        }
+
+        BufferedImage renderAndCaptureFramebuffer() {
+            captureRequested = true;
+            framebufferImage = null;
+            try {
+                render();
+                return getFramebufferImage();
+            } finally {
+                captureRequested = false;
+            }
+        }
+
+        private BufferedImage getFramebufferImage() {
+            if (framebufferImage == null) {
+                throw new IllegalStateException("The OpenGL canvas has not been rendered");
+            }
+            return framebufferImage;
         }
 
         public void initGL() {
@@ -338,6 +357,14 @@ public class CompareScreenshotTest {
         public void paintGL() {
             int w = getFramebufferWidth();
             int h = getFramebufferHeight();
+            drawScene(w, h);
+            if (captureRequested) {
+                framebufferImage = captureOffscreen(getWidth(), getHeight());
+            }
+            swapBuffers();
+        }
+
+        private void drawScene(int w, int h) {
             float aspect = (float) w / h;
             double now = 100;
             float width = (float) Math.abs(Math.sin(now * 0.3));
@@ -350,7 +377,41 @@ public class CompareScreenshotTest {
             glVertex2f(+0.75f * width / aspect, 0);
             glVertex2f(0, +0.75f);
             glEnd();
-            swapBuffers();
+        }
+
+        private BufferedImage captureOffscreen(int width, int height) {
+            int previousFramebuffer = glGetInteger(GL_FRAMEBUFFER_BINDING_EXT);
+            int previousRenderbuffer = glGetInteger(GL_RENDERBUFFER_BINDING_EXT);
+            int previousDrawBuffer = glGetInteger(GL_DRAW_BUFFER);
+            int previousReadBuffer = glGetInteger(GL_READ_BUFFER);
+            int framebuffer = glGenFramebuffersEXT();
+            int colorBuffer = glGenRenderbuffersEXT();
+            try {
+                glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, framebuffer);
+                glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, colorBuffer);
+                glRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_RGBA8, width, height);
+                glFramebufferRenderbufferEXT(
+                        GL_FRAMEBUFFER_EXT,
+                        GL_COLOR_ATTACHMENT0_EXT,
+                        GL_RENDERBUFFER_EXT,
+                        colorBuffer);
+                int status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+                if (status != GL_FRAMEBUFFER_COMPLETE_EXT) {
+                    throw new IllegalStateException("Incomplete screenshot framebuffer: 0x" + Integer.toHexString(status));
+                }
+
+                glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT);
+                glReadBuffer(GL_COLOR_ATTACHMENT0_EXT);
+                drawScene(width, height);
+                return readFramebuffer(width, height);
+            } finally {
+                glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, previousFramebuffer);
+                glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, previousRenderbuffer);
+                glDrawBuffer(previousDrawBuffer);
+                glReadBuffer(previousReadBuffer);
+                glDeleteRenderbuffersEXT(colorBuffer);
+                glDeleteFramebuffersEXT(framebuffer);
+            }
         }
     }
 }


### PR DESCRIPTION
Replaces `java.awt.Robot` screen capture with offscreen Swing painting and OpenGL framebuffer readback. This keeps screenshot comparisons deterministic without requiring macOS Screen Recording or window-picker permissions, and restores macOS CI to macos-latest.

- Ran all four CompareScreenshotTest scenarios individually on macOS with JDK 17; all passed.
- Verified the test suite no longer uses Robot or createScreenCapture.
- Verified clean test compilation with JDK 8.
- Still requires full validation on a fresh macos-latest runner is pending GitHub Actions.

Fixes #95.