### PR TITLE
Scope JAWT drawing surfaces to render threads

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -59,7 +59,7 @@ public abstract class AWTGLCanvas extends Canvas {
     }
 
     /**
-     * Deletes the OpenGL context and releases the platform drawing surface.
+     * Deletes the OpenGL context and releases platform-specific canvas resources.
      *
      * <p>This method must not run concurrently with rendering. Applications that render on a dedicated thread should
      * override it to arrange cleanup on that thread.</p>

--- a/src/org/lwjgl/opengl/awt/PlatformGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformGLCanvas.java
@@ -15,7 +15,20 @@ public interface PlatformGLCanvas {
     boolean isCurrent(long context);
     boolean swapBuffers();
     boolean delayBeforeSwapNV(float seconds);
+
+    /**
+     * Acquires and locks a JAWT drawing surface for the current render operation.
+     */
     void lock() throws AWTException;
+
+    /**
+     * Unlocks and frees the JAWT drawing surface acquired by {@link #lock()}.
+     * This must be called on the same thread as {@code lock()}.
+     */
     void unlock() throws AWTException;
+
+    /**
+     * Releases platform resources that outlive a drawing-surface lock cycle.
+     */
     void dispose();
 }

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -49,6 +49,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	public long display;
 	public long drawable;
 	public JAWTDrawingSurface ds;
+	private Canvas canvas;
 
 	private long create(int depth, GLData attribs, GLData effective) throws AWTException {
 		int screen = X11.XDefaultScreen(display);
@@ -97,20 +98,38 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	}
 
 	public void lock() throws AWTException {
+		JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
+		if (ds == null) {
+			throw new AWTException("Failed to get JAWT drawing surface");
+		}
 		int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
-		if ((lock & JAWT_LOCK_ERROR) != 0)
+		if ((lock & JAWT_LOCK_ERROR) != 0) {
+			JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
 			throw new AWTException("JAWT_DrawingSurface_Lock() failed");
+		}
+		this.ds = ds;
 	}
 
 	public void unlock() throws AWTException {
-		JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
+		JAWTDrawingSurface ds = this.ds;
+		if (ds == null) {
+			throw new AWTException("JAWT drawing surface is not locked");
+		}
+		try {
+			JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
+		} finally {
+			JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
+			this.ds = null;
+		}
 	}
 
 	public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
-		this.ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
+		this.canvas = canvas;
 		JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
 		try {
-			lock();
+			int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
+			if ((lock & JAWT_LOCK_ERROR) != 0)
+				throw new AWTException("JAWT_DrawingSurface_Lock() failed");
 			try {
 				JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds, ds.GetDrawingSurfaceInfo());
 				try {
@@ -123,7 +142,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 					JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
 				}
 			} finally {
-				unlock();
+				JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
 			}
 		} finally {
 			JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
@@ -155,10 +174,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	}
 
 	public void dispose() {
-		if (this.ds != null) {
-			JAWT_FreeDrawingSurface(this.ds, awt.FreeDrawingSurface());
-			this.ds = null;
-		}
+		canvas = null;
 	}
 
 	private static void verifyGLXCapabilities(long display, int screen, GLData data) throws AWTException {

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -98,7 +98,6 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     @Override
     public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
-        this.ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         this.canvas = canvas;
         if (!hierarchyListenerAdded) {
             canvas.addHierarchyListener(e -> {
@@ -433,22 +432,35 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     @Override
     public void lock() throws AWTException {
+        JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
+        if (ds == null) {
+            throw new AWTException("Failed to get JAWT drawing surface");
+        }
         int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
-        if ((lock & JAWT_LOCK_ERROR) != 0)
+        if ((lock & JAWT_LOCK_ERROR) != 0) {
+            JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
             throw new AWTException("JAWT_DrawingSurface_Lock() failed");
+        }
+        this.ds = ds;
     }
 
     @Override
-    public void unlock() {
-        JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
+    public void unlock() throws AWTException {
+        JAWTDrawingSurface ds = this.ds;
+        if (ds == null) {
+            throw new AWTException("JAWT drawing surface is not locked");
+        }
+        try {
+            JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
+        } finally {
+            JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
+            this.ds = null;
+        }
     }
 
     @Override
     public void dispose() {
-        if (this.ds != null) {
-            JAWT_FreeDrawingSurface(this.ds, awt.FreeDrawingSurface());
-            this.ds = null;
-        }
+        canvas = null;
     }
 
 }

--- a/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
@@ -74,6 +74,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
     public long wglDelayBeforeSwapNVAddr = 0L;
     public boolean wglDelayBeforeSwapNVAddr_set = false;
     public JAWTDrawingSurface ds;
+    private Canvas canvas;
 
     /**
      * Encode the pixel format attributes stored in the given {@link GLData} into the given {@link IntBuffer} for wglChoosePixelFormatARB to consume.
@@ -139,7 +140,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
 
     @Override
     public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
-        this.ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
+        this.canvas = canvas;
         JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         try {
             int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
@@ -802,20 +803,35 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
 
     @Override
     public void lock() throws AWTException {
+        JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
+        if (ds == null) {
+            throw new AWTException("Failed to get JAWT drawing surface");
+        }
         int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
-        if ((lock & JAWT_LOCK_ERROR) != 0)
+        if ((lock & JAWT_LOCK_ERROR) != 0) {
+            JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
             throw new AWTException("JAWT_DrawingSurface_Lock() failed");
+        }
+        this.ds = ds;
     }
 
     @Override
     public void unlock() throws AWTException {
-        JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
+        JAWTDrawingSurface ds = this.ds;
+        if (ds == null) {
+            throw new AWTException("JAWT drawing surface is not locked");
+        }
+        try {
+            JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
+        } finally {
+            JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
+            this.ds = null;
+        }
     }
 
     @Override
     public void dispose() {
-        JAWT_FreeDrawingSurface(this.ds, awt.FreeDrawingSurface());
-        this.ds = null;
+        canvas = null;
     }
 
 }

--- a/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
+++ b/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
@@ -1,0 +1,65 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.Test;
+import org.lwjgl.opengl.GL;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import java.awt.Dimension;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class JAWTDrawingSurfaceThreadLifetimeTest {
+
+    @Test
+    void disposesCanvasAfterRenderingThreadExits() throws Exception {
+        AtomicReference<AWTGLCanvas> canvasRef = new AtomicReference<>();
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+
+        SwingUtilities.invokeAndWait(() -> {
+            AWTGLCanvas canvas = new AWTGLCanvas(new GLData()) {
+                @Override
+                public void initGL() {
+                    GL.createCapabilities();
+                }
+
+                @Override
+                public void paintGL() {
+                    swapBuffers();
+                }
+            };
+            canvas.setPreferredSize(new Dimension(320, 240));
+
+            JFrame frame = new JFrame("dispose-after-render-thread-exits");
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            frame.getContentPane().add(canvas);
+            frame.pack();
+            frame.setVisible(true);
+
+            canvasRef.set(canvas);
+            frameRef.set(frame);
+        });
+
+        AtomicReference<Throwable> renderFailure = new AtomicReference<>();
+        Thread renderer = new Thread(() -> {
+            try {
+                canvasRef.get().render();
+            } catch (Throwable t) {
+                renderFailure.set(t);
+            }
+        }, "short-lived-renderer");
+        renderer.start();
+        renderer.join(TimeUnit.SECONDS.toMillis(10));
+        assertFalse(renderer.isAlive(), "Rendering thread did not exit");
+
+        SwingUtilities.invokeAndWait(() -> frameRef.get().getContentPane().remove(canvasRef.get()));
+        SwingUtilities.invokeAndWait(frameRef.get()::dispose);
+
+        if (renderFailure.get() != null) {
+            fail("Rendering failed", renderFailure.get());
+        }
+    }
+}


### PR DESCRIPTION
Acquires and frees JAWT drawing surfaces within the same render-thread `lock()`/`unlock()` cycle instead of caching them until canvas disposal. This prevents JVM crashes when the rendering thread exits before `removeNotify()` runs on the EDT.

Applied consistently to macOS, Linux, and Windows, with a regression test for the reported lifecycle.

Testing:

- Reproduced the crash on macOS before the fix
- Regression and rendering tests pass on macOS
- Linux lifecycle tests pass under JDK 8/Xvfb
- Clean JDK 8 compilation passes

Fixes #121.