### PR TITLE
Fix Windows Mesa installation in unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
           java-version: 8
           distribution: 'zulu'
           cache: maven
-      - name: Install Mesa next to the JDK
+      - name: Register Mesa as the OpenGL driver
         shell: pwsh
         env:
           MESA_VERSION: '26.1.4'
@@ -82,21 +82,21 @@ jobs:
           if ($hash -ne $env:MESA_SHA256.ToUpper()) {
             throw "Mesa checksum mismatch: expected $env:MESA_SHA256, got $hash"
           }
-          7z x "$archive" "-o$extracted" 'x64\opengl32.dll' 'x64\libgallium_wgl.dll' 'x64\dxil.dll'
-          # System32 is owned by TrustedInstaller, so deploy per-application instead: the loader
-          # searches the directory of the running executable before System32. Surefire forks
-          # ${java.home}/bin/java, which on JDK 8 is the jre subdirectory, so cover every java.exe.
-          $targets = @(Get-ChildItem -Path $env:JAVA_HOME -Recurse -Depth 2 -Filter 'java.exe' |
-            Select-Object -ExpandProperty DirectoryName -Unique)
-          if ($targets.Count -eq 0) { throw "No java.exe found under $env:JAVA_HOME" }
-          foreach ($target in $targets) {
-            foreach ($dll in @('opengl32.dll', 'libgallium_wgl.dll', 'dxil.dll')) {
-              $source = Join-Path $extracted "x64\$dll"
-              if (-not (Test-Path $source)) { throw "Mesa archive did not contain x64\$dll" }
-              Copy-Item $source -Destination $target -Force
-            }
-            Write-Host "Deployed Mesa to $target"
-          }
+          7z x "$archive" "-o$extracted" 'x64\libgallium_wgl.dll' 'x64\dxil.dll'
+          # This mirrors Mesa's own systemwidedeploy.cmd: rather than overwriting the
+          # TrustedInstaller-owned opengl32.dll, install the Gallium driver as mesadrv.dll and let
+          # the system opengl32.dll load it as the MSOGL installable client driver.
+          $system32 = Join-Path $env:SystemRoot 'System32'
+          Copy-Item (Join-Path $extracted 'x64\libgallium_wgl.dll') (Join-Path $system32 'mesadrv.dll') -Force
+          Copy-Item (Join-Path $extracted 'x64\dxil.dll') $system32 -Force
+          $key = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL'
+          New-Item -Path $key -Force | Out-Null
+          Set-ItemProperty -Path $key -Name 'DLL' -Value 'mesadrv.dll' -Type String
+          Set-ItemProperty -Path $key -Name 'DriverVersion' -Value 1 -Type DWord
+          Set-ItemProperty -Path $key -Name 'Flags' -Value 1 -Type DWord
+          Set-ItemProperty -Path $key -Name 'Version' -Value 2 -Type DWord
+          Get-Item (Join-Path $system32 'mesadrv.dll') | Format-Table Name, Length
+          Get-ItemProperty -Path $key | Format-List DLL, DriverVersion, Flags, Version
       - name: Build with Maven
         run: ./mvnw -B test
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,19 +67,28 @@ jobs:
           java-version: 8
           distribution: 'zulu'
           cache: maven
-      - name: Download Mesa
-        uses: carlosperate/download-file-action@7021d227a45dcf2f828612344b03f6f09a4f7cad # v2.0.3
-        with:
-          file-url: 'https://downloads.fdossena.com/geth.php?r=mesa64-latest'
-          file-name: 'mesa64-latest.7z'
-          location: '.'
       - name: Overwrite opengl32.dll with Mesa
-        uses: DuckSoft/extract-7z-action@6eaaa506b410f047eaa9b22498696aad1e19a834 # v1.0
-        with:
-          pathSource: mesa64-latest.7z
-          pathTarget: C:\WINDOWS\SYSTEM32\
+        shell: pwsh
+        env:
+          MESA_VERSION: '26.1.4'
+          MESA_SHA256: '3804c66059c17b7ce12ca8596782585547e20c2185938f89663ec7b807ef0a84'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $archive = Join-Path $env:RUNNER_TEMP 'mesa.7z'
+          $extracted = Join-Path $env:RUNNER_TEMP 'mesa'
+          $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$env:MESA_VERSION/mesa3d-$env:MESA_VERSION-release-msvc.7z"
+          curl.exe --fail --location --retry 5 --retry-all-errors --retry-delay 10 --output "$archive" "$url"
+          $hash = (Get-FileHash "$archive" -Algorithm SHA256).Hash
+          if ($hash -ne $env:MESA_SHA256.ToUpper()) {
+            throw "Mesa checksum mismatch: expected $env:MESA_SHA256, got $hash"
+          }
+          7z x "$archive" "-o$extracted" 'x64\opengl32.dll' 'x64\libgallium_wgl.dll' 'x64\dxil.dll'
+          Copy-Item (Join-Path $extracted 'x64\*.dll') -Destination "$env:SystemRoot\System32\" -Force
       - name: Build with Maven
         run: ./mvnw -B test
+        env:
+          GALLIUM_DRIVER: llvmpipe
+          LIBGL_ALWAYS_SOFTWARE: '1'
       - name: Upload Images
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
           java-version: 8
           distribution: 'zulu'
           cache: maven
-      - name: Overwrite opengl32.dll with Mesa
+      - name: Install Mesa next to the JDK
         shell: pwsh
         env:
           MESA_VERSION: '26.1.4'
@@ -83,7 +83,15 @@ jobs:
             throw "Mesa checksum mismatch: expected $env:MESA_SHA256, got $hash"
           }
           7z x "$archive" "-o$extracted" 'x64\opengl32.dll' 'x64\libgallium_wgl.dll' 'x64\dxil.dll'
-          Copy-Item (Join-Path $extracted 'x64\*.dll') -Destination "$env:SystemRoot\System32\" -Force
+          # System32 is owned by TrustedInstaller, so deploy per-application instead: the loader
+          # searches the directory of the running executable (java.exe) before System32.
+          $target = Join-Path $env:JAVA_HOME 'bin'
+          foreach ($dll in @('opengl32.dll', 'libgallium_wgl.dll', 'dxil.dll')) {
+            $source = Join-Path $extracted "x64\$dll"
+            if (-not (Test-Path $source)) { throw "Mesa archive did not contain x64\$dll" }
+            Copy-Item $source -Destination $target -Force
+          }
+          Get-ChildItem $target -Filter '*gl*.dll' | Format-Table Name, Length
       - name: Build with Maven
         run: ./mvnw -B test
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,14 +84,19 @@ jobs:
           }
           7z x "$archive" "-o$extracted" 'x64\opengl32.dll' 'x64\libgallium_wgl.dll' 'x64\dxil.dll'
           # System32 is owned by TrustedInstaller, so deploy per-application instead: the loader
-          # searches the directory of the running executable (java.exe) before System32.
-          $target = Join-Path $env:JAVA_HOME 'bin'
-          foreach ($dll in @('opengl32.dll', 'libgallium_wgl.dll', 'dxil.dll')) {
-            $source = Join-Path $extracted "x64\$dll"
-            if (-not (Test-Path $source)) { throw "Mesa archive did not contain x64\$dll" }
-            Copy-Item $source -Destination $target -Force
+          # searches the directory of the running executable before System32. Surefire forks
+          # ${java.home}/bin/java, which on JDK 8 is the jre subdirectory, so cover every java.exe.
+          $targets = @(Get-ChildItem -Path $env:JAVA_HOME -Recurse -Depth 2 -Filter 'java.exe' |
+            Select-Object -ExpandProperty DirectoryName -Unique)
+          if ($targets.Count -eq 0) { throw "No java.exe found under $env:JAVA_HOME" }
+          foreach ($target in $targets) {
+            foreach ($dll in @('opengl32.dll', 'libgallium_wgl.dll', 'dxil.dll')) {
+              $source = Join-Path $extracted "x64\$dll"
+              if (-not (Test-Path $source)) { throw "Mesa archive did not contain x64\$dll" }
+              Copy-Item $source -Destination $target -Force
+            }
+            Write-Host "Deployed Mesa to $target"
           }
-          Get-ChildItem $target -Filter '*gl*.dll' | Format-Table Name, Length
       - name: Build with Maven
         run: ./mvnw -B test
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,11 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<!-- A windowing deadlock would otherwise hang until the CI job times out. Fail fast
+					     instead: surefire dumps the forked VM's stack traces when this elapses. -->
+					<forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
+				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -92,6 +92,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     public JAWTDrawingSurface ds;
     private Canvas canvas;
     private long view;
+    private long interLayer;
     private boolean hierarchyListenerAdded;
     private int width;
     private int height;
@@ -109,6 +110,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
             });
             hierarchyListenerAdded = true;
         }
+        long context;
+        long surfaceLayer;
         JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         try {
             int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
@@ -208,9 +211,12 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                     long pixelFormat = invokePPP(NSOpenGLPixelFormat, sel_getUid("alloc"), objc_msgSend);
                     pixelFormat = invokePPPP(pixelFormat, sel_getUid("initWithAttributes:"), MemoryUtil.memAddress(attribsArray), objc_msgSend);
 
-                    view = createNSOpenGLView(dsi.platformInfo(), pixelFormat, x, y, width, height);
+                    view = createNSOpenGLView(pixelFormat, x, y, width, height);
+                    // The surface layer belongs to the peer view rather than to the drawing surface info, but
+                    // retain it anyway so it stays alive until the layer has been attached below.
+                    surfaceLayer = invokePPP(dsi.platformInfo(), sel_getUid("retain"), objc_msgSend);
                     long openGLContext = invokePPP(view, sel_getUid("openGLContext"), objc_msgSend);
-                    return invokePPP(openGLContext, sel_getUid("CGLContextObj"), objc_msgSend);
+                    context = invokePPP(openGLContext, sel_getUid("CGLContextObj"), objc_msgSend);
                 } finally {
                     JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
                 }
@@ -220,9 +226,31 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         } finally {
             JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
         }
+
+        try {
+            attachSurfaceLayer(surfaceLayer, interLayer);
+        } finally {
+            invokePPP(surfaceLayer, sel_getUid("release"), objc_msgSend);
+        }
+        return context;
     }
 
-    private long createNSOpenGLView(long platformInfo, long pixelFormat, int x, int y, int width, int height) {
+    /**
+     * Hands the view's layer tree to the JAWT surface layer on AppKit's main thread.
+     *
+     * <p>This waits for AppKit to run the selector, so it must not be called while the JAWT drawing surface is
+     * locked: AppKit takes that same lock, so waiting for it here would deadlock the two threads.</p>
+     */
+    private static void attachSurfaceLayer(long surfaceLayer, long layer) {
+        JNI.callPPPPV(surfaceLayer,
+                ObjCRuntime.sel_getUid("performSelectorOnMainThread:withObject:waitUntilDone:"),
+                ObjCRuntime.sel_getUid("setLayer:"),
+                layer,
+                ObjCRuntime.YES,
+                objc_msgSend);
+    }
+
+    private long createNSOpenGLView(long pixelFormat, int x, int y, int width, int height) {
         long objc_msgSend = ObjCRuntime.getLibrary().getFunctionAddress("objc_msgSend");
 
         // NSOpenGLView *nsOpenGLView = [NSOpenGLView alloc];
@@ -256,7 +284,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
         // create intermediate layer and set its frame
         // CALayer *interLayer = [CALayer layer];
-		long interLayer = JNI.invokePPP(
+		interLayer = JNI.invokePPP(
                 ObjCRuntime.objc_getClass("CALayer"),
                 ObjCRuntime.sel_getUid("layer"),
                 objc_msgSend);
@@ -271,13 +299,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                 openglViewLayer,
                 objc_msgSend);
 
-        // set intermediate layer as JAWTSurfaceLayer's layer
-        JNI.callPPPPV(platformInfo,
-                ObjCRuntime.sel_getUid("performSelectorOnMainThread:withObject:waitUntilDone:"),
-                ObjCRuntime.sel_getUid("setLayer:"),
-                interLayer,
-                ObjCRuntime.YES,
-                objc_msgSend);
+        // the intermediate layer is handed to the JAWTSurfaceLayer by the caller, once it has released the
+        // drawing surface lock
 
         return view;
     }


### PR DESCRIPTION
The Windows job has been failing since `downloads.fdossena.com` became unreachable (`connect ETIMEDOUT` on the runner). Mesa now comes from the `pal1000/mesa-dist-win` GitHub release, pinned by version and SHA-256, and is installed the way Mesa's own `systemwidedeploy.cmd` does it: the Gallium driver is copied to `System32\mesadrv.dll` and registered as the MSOGL client driver, rather than overwriting the TrustedInstaller-owned `opengl32.dll`. This also drops two third-party actions in favour of the runner's `curl` and `7z`.

Separately, `PlatformMacOSXGLCanvas.create()` no longer performs its `setLayer:` round-trip to the AppKit main thread while holding the JAWT drawing surface lock. AppKit takes that lock itself, so waiting on it there could deadlock the two threads — it hung a macOS run until the job timed out. The surface layer is retained across the unlock so its lifetime doesn't depend on the drawing surface info.

Surefire gets `forkedProcessTimeoutInSeconds` of 180 so a future deadlock fails in three minutes with stack traces instead of twenty minutes of silence.

Windows and Linux are green. macOS still aborts intermittently in `JAWTDrawingSurfaceThreadLifetimeTest` (~1 run in 5): that test renders from a non-EDT thread, so the `NSOpenGLView` is constructed off the AppKit main thread. That predates this branch — it first aborted on a commit that changed only the workflow file — and is left for a follow-up. I'll create a separate issue for this.