### PR TITLE
Make AWTGLCanvas lifecycle thread-safe

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -15,7 +15,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * An AWT {@link Canvas} that supports to be drawn on using OpenGL.
  *
  * <p>Rendering and context callbacks execute while this canvas's lifecycle lock is held. They must not synchronously
- * wait for AWT's event-dispatch thread, because that thread may be waiting to remove or dispose this canvas.</p>
+ * wait for AWT's event-dispatch thread or acquire AWT's tree lock, because that thread may already hold the tree lock
+ * while waiting to remove or dispose this canvas. Post AWT work asynchronously instead.</p>
  * 
  * @author Kai Burjack
  */
@@ -113,26 +114,82 @@ public abstract class AWTGLCanvas extends Canvas {
         } catch (AWTException e) {
             throw new RuntimeException("Failed to lock Canvas", e);
         }
-        platformCanvas.makeCurrent(context);
+        try {
+            if (!platformCanvas.makeCurrent(context)) {
+                throw new IllegalStateException("Failed to make the OpenGL context current");
+            }
+        } catch (RuntimeException | Error failure) {
+            releaseDrawingSurfaceAfterFailure(failure);
+            throw failure;
+        }
     }
 
     protected void afterRender() {
-        platformCanvas.makeCurrent(0L);
+        Throwable failure = null;
+        try {
+            if (!platformCanvas.makeCurrent(0L)) {
+                failure = new IllegalStateException("Failed to clear the current OpenGL context");
+            }
+        } catch (RuntimeException | Error e) {
+            failure = e;
+        }
         try {
             platformCanvas.unlock(); // <- MUST unlock on Linux
         } catch (AWTException e) {
-            throw new RuntimeException("Failed to unlock Canvas", e);
+            RuntimeException unlockFailure = new RuntimeException("Failed to unlock Canvas", e);
+            if (failure == null) {
+                failure = unlockFailure;
+            } else {
+                failure.addSuppressed(unlockFailure);
+            }
+        } catch (RuntimeException | Error e) {
+            if (failure == null) {
+                failure = e;
+            } else {
+                failure.addSuppressed(e);
+            }
         }
+        if (failure != null) {
+            rethrow(failure);
+        }
+    }
+
+    private void releaseDrawingSurfaceAfterFailure(Throwable failure) {
+        try {
+            if (!platformCanvas.makeCurrent(0L)) {
+                failure.addSuppressed(new IllegalStateException("Failed to clear the current OpenGL context"));
+            }
+        } catch (RuntimeException | Error e) {
+            failure.addSuppressed(e);
+        }
+        try {
+            platformCanvas.unlock();
+        } catch (AWTException e) {
+            failure.addSuppressed(new RuntimeException("Failed to unlock Canvas", e));
+        } catch (RuntimeException | Error e) {
+            failure.addSuppressed(e);
+        }
+    }
+
+    private static void rethrow(Throwable failure) {
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
+        throw (RuntimeException) failure;
     }
 
     public <T> T executeInContext(Callable<T> callable) throws Exception {
         lifecycleLock.lock();
         try {
             beforeRender();
+            Throwable callbackFailure = null;
             try {
                 return callable.call();
+            } catch (Exception | Error failure) {
+                callbackFailure = failure;
+                throw failure;
             } finally {
-                afterRender();
+                afterRender(callbackFailure);
             }
         } finally {
             lifecycleLock.unlock();
@@ -143,10 +200,14 @@ public abstract class AWTGLCanvas extends Canvas {
         lifecycleLock.lock();
         try {
             beforeRender();
+            Throwable callbackFailure = null;
             try {
                 runnable.run();
+            } catch (RuntimeException | Error failure) {
+                callbackFailure = failure;
+                throw failure;
             } finally {
-                afterRender();
+                afterRender(callbackFailure);
             }
         } finally {
             lifecycleLock.unlock();
@@ -156,24 +217,43 @@ public abstract class AWTGLCanvas extends Canvas {
     /**
      * Makes this canvas's context current and invokes {@link #initGL()} when necessary, followed by {@link #paintGL()}.
      *
-     * <p>The callbacks run while the lifecycle lock is held and must not call {@link EventQueue#invokeAndWait(Runnable)}
-     * or otherwise wait synchronously for the event-dispatch thread.</p>
+     * <p>The callbacks run while the lifecycle lock is held. They must not call
+     * {@link EventQueue#invokeAndWait(Runnable)}, synchronize on {@link Component#getTreeLock()}, or invoke AWT/Swing
+     * operations that acquire the tree lock. Such calls can deadlock with canvas removal on the event-dispatch thread.
+     * Post AWT work asynchronously instead.</p>
      */
     public void render() {
         lifecycleLock.lock();
         try {
             beforeRender();
+            Throwable callbackFailure = null;
             try {
                 if (!initCalled) {
                     initGL();
                     initCalled = true;
                 }
                 paintGL();
+            } catch (RuntimeException | Error failure) {
+                callbackFailure = failure;
+                throw failure;
             } finally {
-                afterRender();
+                afterRender(callbackFailure);
             }
         } finally {
             lifecycleLock.unlock();
+        }
+    }
+
+    private void afterRender(Throwable callbackFailure) {
+        try {
+            afterRender();
+        } catch (RuntimeException | Error cleanupFailure) {
+            if (callbackFailure == null) {
+                throw cleanupFailure;
+            }
+            if (callbackFailure != cleanupFailure) {
+                callbackFailure.addSuppressed(cleanupFailure);
+            }
         }
     }
 

--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -9,9 +9,13 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.util.concurrent.Callable;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * An AWT {@link Canvas} that supports to be drawn on using OpenGL.
+ *
+ * <p>Rendering and context callbacks execute while this canvas's lifecycle lock is held. They must not synchronously
+ * wait for AWT's event-dispatch thread, because that thread may be waiting to remove or dispose this canvas.</p>
  * 
  * @author Kai Burjack
  */
@@ -36,6 +40,7 @@ public abstract class AWTGLCanvas extends Canvas {
     protected final GLData data;
     protected final GLData effective = new GLData();
     protected boolean initCalled;
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
     private int framebufferWidth, framebufferHeight;
     private final ComponentListener listener = new ComponentAdapter() {
         @Override
@@ -49,8 +54,13 @@ public abstract class AWTGLCanvas extends Canvas {
 
     @Override
     public void removeNotify() {
-        super.removeNotify();
-        disposeCanvas();
+        lifecycleLock.lock();
+        try {
+            super.removeNotify();
+            disposeCanvas();
+        } finally {
+            lifecycleLock.unlock();
+        }
     }
 
     @Override
@@ -61,19 +71,24 @@ public abstract class AWTGLCanvas extends Canvas {
     /**
      * Deletes the OpenGL context and releases platform-specific canvas resources.
      *
-     * <p>This method must not run concurrently with rendering. Applications that render on a dedicated thread should
-     * override it to arrange cleanup on that thread.</p>
+     * <p>If rendering is in progress on another thread, this method waits for that operation to finish before deleting
+     * the context. Applications remain responsible for stopping any render loop before disposing the canvas.</p>
      */
     public void disposeCanvas() {
+        lifecycleLock.lock();
         try {
-            if (context != 0L) {
-                platformCanvas.deleteContext(context);
+            try {
+                if (context != 0L) {
+                    platformCanvas.deleteContext(context);
+                }
+            } finally {
+                // prepare for a possible re-adding
+                context = 0L;
+                initCalled = false;
+                platformCanvas.dispose();
             }
         } finally {
-            // prepare for a possible re-adding
-            context = 0L;
-            initCalled = false;
-            platformCanvas.dispose();
+            lifecycleLock.unlock();
         }
     }
     protected AWTGLCanvas(GLData data) {
@@ -111,33 +126,54 @@ public abstract class AWTGLCanvas extends Canvas {
     }
 
     public <T> T executeInContext(Callable<T> callable) throws Exception {
-        beforeRender();
+        lifecycleLock.lock();
         try {
-            return callable.call();
+            beforeRender();
+            try {
+                return callable.call();
+            } finally {
+                afterRender();
+            }
         } finally {
-            afterRender();
+            lifecycleLock.unlock();
         }
     }
 
     public void runInContext(Runnable runnable) {
-        beforeRender();
+        lifecycleLock.lock();
         try {
-            runnable.run();
+            beforeRender();
+            try {
+                runnable.run();
+            } finally {
+                afterRender();
+            }
         } finally {
-            afterRender();
+            lifecycleLock.unlock();
         }
     }
 
+    /**
+     * Makes this canvas's context current and invokes {@link #initGL()} when necessary, followed by {@link #paintGL()}.
+     *
+     * <p>The callbacks run while the lifecycle lock is held and must not call {@link EventQueue#invokeAndWait(Runnable)}
+     * or otherwise wait synchronously for the event-dispatch thread.</p>
+     */
     public void render() {
-        beforeRender();
+        lifecycleLock.lock();
         try {
-            if (!initCalled) {
-                initGL();
-                initCalled = true;
+            beforeRender();
+            try {
+                if (!initCalled) {
+                    initGL();
+                    initCalled = true;
+                }
+                paintGL();
+            } finally {
+                afterRender();
             }
-            paintGL();
         } finally {
-            afterRender();
+            lifecycleLock.unlock();
         }
     }
 
@@ -159,8 +195,19 @@ public abstract class AWTGLCanvas extends Canvas {
         return framebufferHeight;
     }
 
+    /**
+     * Swaps this canvas's buffers without making its context current.
+     *
+     * <p>Call this only while the context is current, normally from {@link #paintGL()} or a callback passed to
+     * {@link #runInContext(Runnable)} or {@link #executeInContext(Callable)}.</p>
+     */
     public final void swapBuffers() {
-        platformCanvas.swapBuffers();
+        lifecycleLock.lock();
+        try {
+            platformCanvas.swapBuffers();
+        } finally {
+            lifecycleLock.unlock();
+        }
     }
     
     /**

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -427,9 +427,14 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     @Override
     public boolean makeCurrent(long context) {
-        CGLSetCurrentContext(context);
+        if (CGLSetCurrentContext(context) != kCGLNoError) {
+            return false;
+        }
         if (context != 0L) {
             JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds, ds.GetDrawingSurfaceInfo());
+            if (dsi == null) {
+                return false;
+            }
             try {
                 int width = dsi.bounds().width();
                 int height = dsi.bounds().height();
@@ -438,8 +443,11 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                     AffineTransform transform = canvas.getGraphicsConfiguration().getDefaultTransform();
                     int backingWidth = (int) (width * transform.getScaleX());
                     int backingHeight = (int) (height * transform.getScaleY());
-                    CGLSetParameter(context, kCGLCPSurfaceBackingSize, new int[]{backingWidth, backingHeight});
-                    CGLEnable(context, kCGLCESurfaceBackingSize);
+                    if (CGLSetParameter(context, kCGLCPSurfaceBackingSize,
+                            new int[]{backingWidth, backingHeight}) != kCGLNoError
+                            || CGLEnable(context, kCGLCESurfaceBackingSize) != kCGLNoError) {
+                        return false;
+                    }
                     this.width = width;
                     this.height = height;
                 }

--- a/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
@@ -6,11 +6,17 @@ import java.awt.AWTException;
 import java.awt.Canvas;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AWTGLCanvasLifecycleTest {
 
@@ -91,6 +97,120 @@ class AWTGLCanvasLifecycleTest {
                 platform.calls);
     }
 
+    @Test
+    void disposeCanvasWaitsForInFlightRender() throws Exception {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        CountDownLatch paintStarted = new CountDownLatch(1);
+        CountDownLatch finishPaint = new CountDownLatch(1);
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            public void paintGL() {
+                platform.calls.add("paint:start");
+                paintStarted.countDown();
+                try {
+                    if (!finishPaint.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("Timed out waiting to finish paintGL");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("Interrupted while painting", e);
+                }
+                platform.calls.add("paint:end");
+            }
+        };
+        AtomicReference<Throwable> renderFailure = new AtomicReference<>();
+        AtomicReference<Throwable> disposeFailure = new AtomicReference<>();
+
+        Thread renderer = new Thread(() -> runAndRecordFailure(canvas::render, renderFailure), "lifecycle-renderer");
+        renderer.start();
+        assertTrue(paintStarted.await(5, TimeUnit.SECONDS), "Rendering did not reach paintGL");
+
+        CountDownLatch disposeStarted = new CountDownLatch(1);
+        Thread disposer = new Thread(() -> {
+            disposeStarted.countDown();
+            runAndRecordFailure(canvas::disposeCanvas, disposeFailure);
+        }, "lifecycle-disposer");
+        disposer.start();
+        assertTrue(disposeStarted.await(5, TimeUnit.SECONDS), "Disposal did not start");
+
+        boolean deletedDuringRender;
+        try {
+            deletedDuringRender = platform.deleteCalled.await(250, TimeUnit.MILLISECONDS);
+        } finally {
+            finishPaint.countDown();
+            renderer.join(TimeUnit.SECONDS.toMillis(5));
+            disposer.join(TimeUnit.SECONDS.toMillis(5));
+        }
+
+        assertFalse(deletedDuringRender, "Context was deleted while paintGL was still running");
+        assertFalse(renderer.isAlive(), "Rendering thread did not exit");
+        assertFalse(disposer.isAlive(), "Disposal thread did not exit");
+        assertNull(renderFailure.get(), "Rendering failed");
+        assertNull(disposeFailure.get(), "Disposal failed");
+        assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "paint:start", "paint:end",
+                "makeCurrent:0", "unlock", "delete:42", "dispose"), platform.calls);
+    }
+
+    @Test
+    void lifecycleLocksDoNotSerializeDifferentCanvases() throws Exception {
+        CountDownLatch firstPaintStarted = new CountDownLatch(1);
+        CountDownLatch finishFirstPaint = new CountDownLatch(1);
+        CountDownLatch secondPaintFinished = new CountDownLatch(1);
+        TestCanvas firstCanvas = new TestCanvas(new RecordingPlatformCanvas()) {
+            @Override
+            public void paintGL() {
+                firstPaintStarted.countDown();
+                try {
+                    if (!finishFirstPaint.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("Timed out waiting to finish first canvas");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("Interrupted while painting first canvas", e);
+                }
+            }
+        };
+        TestCanvas secondCanvas = new TestCanvas(new RecordingPlatformCanvas()) {
+            @Override
+            public void paintGL() {
+                secondPaintFinished.countDown();
+            }
+        };
+        AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+        AtomicReference<Throwable> secondFailure = new AtomicReference<>();
+
+        Thread firstRenderer = new Thread(
+                () -> runAndRecordFailure(firstCanvas::render, firstFailure), "first-canvas-renderer");
+        Thread secondRenderer = new Thread(
+                () -> runAndRecordFailure(secondCanvas::render, secondFailure), "second-canvas-renderer");
+        firstRenderer.start();
+        assertTrue(firstPaintStarted.await(5, TimeUnit.SECONDS), "First canvas did not reach paintGL");
+
+        secondRenderer.start();
+        boolean renderedConcurrently;
+        try {
+            renderedConcurrently = secondPaintFinished.await(1, TimeUnit.SECONDS);
+        } finally {
+            finishFirstPaint.countDown();
+            firstRenderer.join(TimeUnit.SECONDS.toMillis(5));
+            secondRenderer.join(TimeUnit.SECONDS.toMillis(5));
+        }
+
+        assertTrue(renderedConcurrently, "A different canvas was blocked by the first canvas's lifecycle lock");
+        assertFalse(firstRenderer.isAlive(), "First rendering thread did not exit");
+        assertFalse(secondRenderer.isAlive(), "Second rendering thread did not exit");
+        assertNull(firstFailure.get(), "First canvas rendering failed");
+        assertNull(secondFailure.get(), "Second canvas rendering failed");
+    }
+
+    private static void runAndRecordFailure(Runnable action, AtomicReference<Throwable> failure) {
+        try {
+            action.run();
+        } catch (Throwable t) {
+            failure.set(t);
+        }
+    }
+
     private static class TestCanvas extends AWTGLCanvas {
         TestCanvas(PlatformGLCanvas platformCanvas) {
             this.platformCanvas = platformCanvas;
@@ -106,7 +226,8 @@ class AWTGLCanvasLifecycleTest {
     }
 
     private static class RecordingPlatformCanvas implements PlatformGLCanvas {
-        final List<String> calls = new ArrayList<>();
+        final List<String> calls = Collections.synchronizedList(new ArrayList<>());
+        final CountDownLatch deleteCalled = new CountDownLatch(1);
         RuntimeException deleteFailure;
 
         @Override
@@ -118,6 +239,7 @@ class AWTGLCanvasLifecycleTest {
         @Override
         public boolean deleteContext(long context) {
             calls.add("delete:" + context);
+            deleteCalled.countDown();
             if (deleteFailure != null) {
                 throw deleteFailure;
             }

--- a/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -93,6 +94,76 @@ class AWTGLCanvasLifecycleTest {
 
         assertThrows(IllegalStateException.class, canvas::render);
 
+        assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "makeCurrent:0", "unlock"),
+                platform.calls);
+    }
+
+    @Test
+    void renderDoesNotInvokeCallbacksWhenMakingContextCurrentFails() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.makeCurrentFailureContext = 42L;
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            public void initGL() {
+                platform.calls.add("init");
+            }
+
+            @Override
+            public void paintGL() {
+                platform.calls.add("paint");
+            }
+        };
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::render);
+
+        assertEquals("Failed to make the OpenGL context current", failure.getMessage());
+        assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "makeCurrent:0", "unlock"),
+                platform.calls);
+    }
+
+    @Test
+    void renderUnlocksDrawingSurfaceWhenClearingCurrentFails() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.makeCurrentFailureContext = 0L;
+        TestCanvas canvas = new TestCanvas(platform);
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::render);
+
+        assertEquals("Failed to clear the current OpenGL context", failure.getMessage());
+        assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "makeCurrent:0", "unlock"),
+                platform.calls);
+    }
+
+    @Test
+    void renderPreservesCallbackFailureWhenCleanupAlsoFails() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.makeCurrentFailureContext = 0L;
+        IllegalStateException paintFailure = new IllegalStateException("paint failed");
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            public void paintGL() {
+                throw paintFailure;
+            }
+        };
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::render);
+
+        assertSame(paintFailure, failure);
+        assertEquals(1, failure.getSuppressed().length);
+        assertEquals("Failed to clear the current OpenGL context", failure.getSuppressed()[0].getMessage());
+        assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "makeCurrent:0", "unlock"),
+                platform.calls);
+    }
+
+    @Test
+    void renderUnlocksDrawingSurfaceWhenMakingContextCurrentThrows() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.makeCurrentExceptionContext = 42L;
+        TestCanvas canvas = new TestCanvas(platform);
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::render);
+
+        assertEquals("make current failed", failure.getMessage());
         assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "makeCurrent:0", "unlock"),
                 platform.calls);
     }
@@ -229,6 +300,8 @@ class AWTGLCanvasLifecycleTest {
         final List<String> calls = Collections.synchronizedList(new ArrayList<>());
         final CountDownLatch deleteCalled = new CountDownLatch(1);
         RuntimeException deleteFailure;
+        long makeCurrentFailureContext = Long.MIN_VALUE;
+        long makeCurrentExceptionContext = Long.MIN_VALUE;
 
         @Override
         public long create(Canvas canvas, GLData data, GLData effective) {
@@ -249,7 +322,10 @@ class AWTGLCanvasLifecycleTest {
         @Override
         public boolean makeCurrent(long context) {
             calls.add("makeCurrent:" + context);
-            return true;
+            if (context == makeCurrentExceptionContext) {
+                throw new IllegalStateException("make current failed");
+            }
+            return context != makeCurrentFailureContext;
         }
 
         @Override


### PR DESCRIPTION
Applications can render an `AWTGLCanvas` on a dedicated thread while AWT removes or disposes it on the event-dispatch thread. Previously, disposal could delete a context or release its drawing surface while rendering was still using it. Failures while changing the current context could also leave the surface locked or hide the original rendering exception.

This adds a reentrant lifecycle lock per canvas around rendering, context callbacks, buffer swapping, removal, and disposal. Cleanup now always attempts to clear the current context and unlock the drawing surface while preserving secondary failures as suppressed exceptions. Separate canvases remain independent, and the callback documentation describes the EDT/tree-lock restriction.

Tests cover disposal during an in-progress render, concurrent rendering on separate canvases, and context and cleanup failure paths. The full test suite passes.
