### PR TITLE
Make framebuffer dimensions authoritative

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -42,14 +42,17 @@ public abstract class AWTGLCanvas extends Canvas {
     protected final GLData effective = new GLData();
     protected boolean initCalled;
     private final ReentrantLock lifecycleLock = new ReentrantLock();
-    private int framebufferWidth, framebufferHeight;
+    private volatile int framebufferWidth;
+    private volatile int framebufferHeight;
     private final ComponentListener listener = new ComponentAdapter() {
         @Override
         public void componentResized(ComponentEvent e) {
-            java.awt.geom.AffineTransform t = AWTGLCanvas.this.getGraphicsConfiguration().getDefaultTransform();
-            float sx = (float) t.getScaleX(), sy = (float) t.getScaleY();
-            AWTGLCanvas.this.framebufferWidth = (int) (getWidth() * sx);
-            AWTGLCanvas.this.framebufferHeight = (int) (getHeight() * sy);
+            updateFramebufferSizeFromComponent();
+        }
+
+        @Override
+        public void componentMoved(ComponentEvent e) {
+            updateFramebufferSizeFromComponent();
         }
     };
 
@@ -95,6 +98,7 @@ public abstract class AWTGLCanvas extends Canvas {
     protected AWTGLCanvas(GLData data) {
         this.data = data;
         this.addComponentListener(listener);
+        this.addPropertyChangeListener("graphicsConfiguration", e -> updateFramebufferSizeFromComponent());
     }
 
     protected AWTGLCanvas() {
@@ -118,6 +122,7 @@ public abstract class AWTGLCanvas extends Canvas {
             if (!platformCanvas.makeCurrent(context)) {
                 throw new IllegalStateException("Failed to make the OpenGL context current");
             }
+            updateFramebufferSize();
         } catch (RuntimeException | Error failure) {
             releaseDrawingSurfaceAfterFailure(failure);
             throw failure;
@@ -273,6 +278,23 @@ public abstract class AWTGLCanvas extends Canvas {
 
     public int getFramebufferHeight() {
         return framebufferHeight;
+    }
+
+    private void updateFramebufferSize() {
+        int[] platformFramebufferSize = new int[2];
+        if (platformCanvas.getFramebufferSize(platformFramebufferSize)) {
+            framebufferWidth = Math.max(0, platformFramebufferSize[0]);
+            framebufferHeight = Math.max(0, platformFramebufferSize[1]);
+        } else {
+            updateFramebufferSizeFromComponent();
+        }
+    }
+
+    private void updateFramebufferSizeFromComponent() {
+        int[] size = new int[2];
+        FramebufferSizeUtil.getScaledSize(this, getWidth(), getHeight(), size);
+        framebufferWidth = size[0];
+        framebufferHeight = size[1];
     }
 
     /**

--- a/src/org/lwjgl/opengl/awt/FramebufferSizeUtil.java
+++ b/src/org/lwjgl/opengl/awt/FramebufferSizeUtil.java
@@ -1,0 +1,27 @@
+package org.lwjgl.opengl.awt;
+
+import java.awt.Canvas;
+import java.awt.GraphicsConfiguration;
+import java.awt.geom.AffineTransform;
+
+final class FramebufferSizeUtil {
+    private FramebufferSizeUtil() {
+    }
+
+    static void getScaledSize(Canvas canvas, int width, int height, int[] size) {
+        double scaleX = 1.0;
+        double scaleY = 1.0;
+        GraphicsConfiguration configuration = canvas.getGraphicsConfiguration();
+        if (configuration != null) {
+            AffineTransform transform = configuration.getDefaultTransform();
+            scaleX = transform.getScaleX();
+            scaleY = transform.getScaleY();
+        }
+        size[0] = scaledDimension(width, scaleX);
+        size[1] = scaledDimension(height, scaleY);
+    }
+
+    private static int scaledDimension(int dimension, double scale) {
+        return Math.max(0, (int) Math.round(dimension * scale));
+    }
+}

--- a/src/org/lwjgl/opengl/awt/PlatformGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformGLCanvas.java
@@ -17,6 +17,19 @@ public interface PlatformGLCanvas {
     boolean delayBeforeSwapNV(float seconds);
 
     /**
+     * Writes the current default-framebuffer width and height to {@code size}.
+     *
+     * <p>This is called while the JAWT drawing surface is locked and the context is current. Implementations should
+     * prefer native drawing-surface dimensions over cached AWT component dimensions.</p>
+     *
+     * @param size an array with room for the width and height
+     * @return {@code true} when authoritative dimensions were available
+     */
+    default boolean getFramebufferSize(int[] size) {
+        return false;
+    }
+
+    /**
      * Acquires and locks a JAWT drawing surface for the current render operation.
      */
     void lock() throws AWTException;

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -12,6 +12,8 @@ import static org.lwjgl.opengl.GLXEXTCreateContextESProfile.*;
 
 import java.awt.AWTException;
 import java.awt.Canvas;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -35,9 +37,13 @@ import org.lwjgl.system.jawt.JAWT;
 import org.lwjgl.system.jawt.JAWTDrawingSurface;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
 import org.lwjgl.system.jawt.JAWTX11DrawingSurfaceInfo;
+import org.lwjgl.system.libffi.FFICIF;
 import org.lwjgl.system.linux.X11;
 
+import static org.lwjgl.system.libffi.LibFFI.*;
+
 public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
+	private static final long X_GET_GEOMETRY = X11.getLibrary().getFunctionAddress("XGetGeometry");
 	public static final JAWT awt;
 	static {
 		awt = JAWT.calloc();
@@ -171,6 +177,78 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 
 	public boolean delayBeforeSwapNV(float seconds) {
 		throw new UnsupportedOperationException("NYI");
+	}
+
+	@Override
+	public boolean getFramebufferSize(int[] size) {
+		if (ds == null || display == 0L || drawable == 0L) {
+			return false;
+		}
+		if (getDrawableSize(display, drawable, size)) {
+			return true;
+		}
+		if (canvas == null) {
+			return false;
+		}
+		JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds, ds.GetDrawingSurfaceInfo());
+		if (dsi == null) {
+			return false;
+		}
+		try {
+			FramebufferSizeUtil.getScaledSize(canvas, dsi.bounds().width(), dsi.bounds().height(), size);
+			return true;
+		} finally {
+			JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
+		}
+	}
+
+	private static boolean getDrawableSize(long display, long drawable, int[] size) {
+		if (X_GET_GEOMETRY == NULL) {
+			return false;
+		}
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			PointerBuffer argumentTypes = stack.pointers(
+					ffi_type_pointer.address(),
+					ffi_type_ulong.address(),
+					ffi_type_pointer.address(),
+					ffi_type_pointer.address(),
+					ffi_type_pointer.address(),
+					ffi_type_pointer.address(),
+					ffi_type_pointer.address(),
+					ffi_type_pointer.address(),
+					ffi_type_pointer.address());
+			FFICIF cif = FFICIF.malloc(stack);
+			if (ffi_prep_cif(cif, FFI_DEFAULT_ABI, ffi_type_sint32, argumentTypes) != FFI_OK) {
+				return false;
+			}
+
+			PointerBuffer root = stack.mallocPointer(1);
+			IntBuffer geometry = stack.mallocInt(6);
+			PointerBuffer values = stack.pointers(
+					display,
+					drawable,
+					memAddress(root),
+					memAddress(geometry, 0),
+					memAddress(geometry, 1),
+					memAddress(geometry, 2),
+					memAddress(geometry, 3),
+					memAddress(geometry, 4),
+					memAddress(geometry, 5));
+			PointerBuffer arguments = stack.mallocPointer(values.remaining());
+			for (int i = 0; i < values.remaining(); i++) {
+				arguments.put(memAddress(values, i));
+			}
+			arguments.flip();
+
+			ByteBuffer result = stack.malloc(Integer.BYTES).order(ByteOrder.nativeOrder());
+			ffi_call(cif, X_GET_GEOMETRY, result, arguments);
+			if (result.getInt(0) == 0) {
+				return false;
+			}
+			size[0] = geometry.get(2);
+			size[1] = geometry.get(3);
+			return true;
+		}
 	}
 
 	public void dispose() {

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -13,7 +13,6 @@ import static org.lwjgl.opengl.GLXEXTCreateContextESProfile.*;
 import java.awt.AWTException;
 import java.awt.Canvas;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +40,7 @@ import org.lwjgl.system.libffi.FFICIF;
 import org.lwjgl.system.linux.X11;
 
 import static org.lwjgl.system.libffi.LibFFI.*;
+import static org.lwjgl.system.Pointer.POINTER_SIZE;
 
 public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	private static final long X_GET_GEOMETRY = X11.getLibrary().getFunctionAddress("XGetGeometry");
@@ -240,9 +240,10 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 			}
 			arguments.flip();
 
-			ByteBuffer result = stack.malloc(Integer.BYTES).order(ByteOrder.nativeOrder());
+			// libffi widens integral return values to ffi_arg, which is pointer-sized.
+			ByteBuffer result = stack.malloc(POINTER_SIZE);
 			ffi_call(cif, X_GET_GEOMETRY, result, arguments);
-			if (result.getInt(0) == 0) {
+			if (PointerBuffer.get(result, 0) == 0L) {
 				return false;
 			}
 			size[0] = geometry.get(2);

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -15,7 +15,6 @@ import org.lwjgl.system.macosx.ObjCRuntime;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.HierarchyEvent;
-import java.awt.geom.AffineTransform;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
@@ -95,8 +94,9 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     private long interLayer;
     private long surfaceLayer;
     private boolean hierarchyListenerAdded;
-    private int width;
-    private int height;
+    private int framebufferWidth;
+    private int framebufferHeight;
+    private final int[] currentFramebufferSize = new int[2];
 
     @Override
     public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
@@ -131,8 +131,9 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                         x = point.x;
                         y = rootPane.getHeight() - point.y - height;
                     }
-                    this.width = width;
-                    this.height = height;
+                    FramebufferSizeUtil.getScaledSize(canvas, width, height, currentFramebufferSize);
+                    this.framebufferWidth = currentFramebufferSize[0];
+                    this.framebufferHeight = currentFramebufferSize[1];
 
                     //TODO: we don't really need 100
                     ByteBuffer attribsArray = ByteBuffer.allocateDirect(4 * 100).order(ByteOrder.nativeOrder());
@@ -438,23 +439,35 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
             try {
                 int width = dsi.bounds().width();
                 int height = dsi.bounds().height();
-                if (width != this.width || height != this.height) {
-                    // [NSOpenGLCotext update] seems bugged. Updating renderer context with CGL works.
-                    AffineTransform transform = canvas.getGraphicsConfiguration().getDefaultTransform();
-                    int backingWidth = (int) (width * transform.getScaleX());
-                    int backingHeight = (int) (height * transform.getScaleY());
-                    if (CGLSetParameter(context, kCGLCPSurfaceBackingSize,
-                            new int[]{backingWidth, backingHeight}) != kCGLNoError
-                            || CGLEnable(context, kCGLCESurfaceBackingSize) != kCGLNoError) {
-                        return false;
-                    }
-                    this.width = width;
-                    this.height = height;
+                FramebufferSizeUtil.getScaledSize(canvas, width, height, currentFramebufferSize);
+                int backingWidth = currentFramebufferSize[0];
+                int backingHeight = currentFramebufferSize[1];
+                // AppKit may recreate a layer-backed drawable without changing the component dimensions, so keep
+                // the CGL backing-size override authoritative on every context activation.
+                if (CGLSetParameter(context, kCGLCPSurfaceBackingSize,
+                        new int[]{backingWidth, backingHeight}) != kCGLNoError
+                        || CGLEnable(context, kCGLCESurfaceBackingSize) != kCGLNoError) {
+                    return false;
                 }
+                if (CGLGetParameter(context, kCGLCPSurfaceBackingSize, currentFramebufferSize) != kCGLNoError) {
+                    return false;
+                }
+                this.framebufferWidth = Math.max(0, currentFramebufferSize[0]);
+                this.framebufferHeight = Math.max(0, currentFramebufferSize[1]);
             } finally {
                 JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
             }
         }
+        return true;
+    }
+
+    @Override
+    public boolean getFramebufferSize(int[] size) {
+        if (canvas == null) {
+            return false;
+        }
+        size[0] = framebufferWidth;
+        size[1] = framebufferHeight;
         return true;
     }
 

--- a/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
@@ -13,6 +13,7 @@ import org.lwjgl.system.jawt.JAWTDrawingSurface;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
 import org.lwjgl.system.jawt.JAWTWin32DrawingSurfaceInfo;
 import org.lwjgl.system.windows.PIXELFORMATDESCRIPTOR;
+import org.lwjgl.system.windows.RECT;
 import org.lwjgl.system.windows.User32;
 import org.lwjgl.system.windows.WNDCLASSEX;
 
@@ -62,6 +63,8 @@ import static org.lwjgl.system.windows.WindowsLibrary.HINSTANCE;
  * @author Kai Burjack
  */
 public class PlatformWin32GLCanvas implements PlatformGLCanvas {
+    // LWJGL's User32 binding does not expose GetClientRect, so resolve it directly from user32.dll.
+    private static final long getClientRectAddr = User32.getLibrary().getFunctionAddress("GetClientRect");
     public static final JAWT awt;
     static {
         awt = JAWT.create(MemoryUtil.getAllocator().calloc(1, JAWT.SIZEOF)); // untracked allocation
@@ -679,6 +682,34 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
             throw new UnsupportedOperationException("wglDelayBeforeSwapNV is unavailable");
         }
         return callPI(hdc, seconds, wglDelayBeforeSwapNVAddr) == 1;
+    }
+
+    @Override
+    public boolean getFramebufferSize(int[] size) {
+        // Only report while the drawing surface is locked; lock() has then verified that this.hwnd is still the
+        // canvas's live peer window.
+        JAWTDrawingSurfaceInfo dsi = this.dsi;
+        long hwnd = this.hwnd;
+        if (dsi == null || hwnd == 0L) {
+            return false;
+        }
+        // JAWT fills dsi.bounds() from the Java component's user-space width/height. The peer HWND's client rectangle
+        // is the actual drawable extent in physical pixels and avoids rounding at fractional scale factors.
+        if (getClientRectAddr != MemoryUtil.NULL) {
+            try (MemoryStack stack = MemoryStack.stackPush()) {
+                RECT rect = RECT.malloc(stack);
+                if (callPPI(hwnd, rect.address(), getClientRectAddr) != 0) {
+                    size[0] = rect.right() - rect.left();
+                    size[1] = rect.bottom() - rect.top();
+                    return true;
+                }
+            }
+        }
+        if (canvas == null) {
+            return false;
+        }
+        FramebufferSizeUtil.getScaledSize(canvas, dsi.bounds().width(), dsi.bounds().height(), size);
+        return true;
     }
 
     @Override

--- a/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
@@ -225,6 +225,19 @@ class AWTGLCanvasLifecycleTest {
     }
 
     @Test
+    void renderUnlocksDrawingSurfaceWhenFramebufferSizeQueryThrows() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.framebufferSizeFailure = new IllegalStateException("size query failed");
+        TestCanvas canvas = new TestCanvas(platform);
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::render);
+
+        assertEquals("size query failed", failure.getMessage());
+        assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "makeCurrent:0", "unlock"),
+                platform.calls);
+    }
+
+    @Test
     void disposeCanvasWaitsForInFlightRender() throws Exception {
         RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
         CountDownLatch paintStarted = new CountDownLatch(1);
@@ -422,6 +435,7 @@ class AWTGLCanvasLifecycleTest {
         final List<String> calls = Collections.synchronizedList(new ArrayList<>());
         final CountDownLatch deleteCalled = new CountDownLatch(1);
         RuntimeException deleteFailure;
+        RuntimeException framebufferSizeFailure;
         long makeCurrentFailureContext = Long.MIN_VALUE;
         long makeCurrentExceptionContext = Long.MIN_VALUE;
         boolean reportsFramebufferSize = true;
@@ -471,6 +485,9 @@ class AWTGLCanvasLifecycleTest {
 
         @Override
         public boolean getFramebufferSize(int[] size) {
+            if (framebufferSizeFailure != null) {
+                throw framebufferSizeFailure;
+            }
             if (!reportsFramebufferSize) {
                 return false;
             }

--- a/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
@@ -4,6 +4,12 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.AWTException;
 import java.awt.Canvas;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.Rectangle;
+import java.awt.Transparency;
+import java.awt.geom.AffineTransform;
+import java.awt.image.ColorModel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,6 +26,56 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AWTGLCanvasLifecycleTest {
+
+    @Test
+    void initializesFramebufferSizeFromDrawingSurfaceBeforeInitGL() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.framebufferWidth = 640;
+        platform.framebufferHeight = 480;
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            public void initGL() {
+                assertEquals(640, getFramebufferWidth());
+                assertEquals(480, getFramebufferHeight());
+            }
+        };
+
+        canvas.render();
+    }
+
+    @Test
+    void refreshesFramebufferSizeFromDrawingSurfaceBeforeEveryRender() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.framebufferWidth = 320;
+        platform.framebufferHeight = 240;
+        TestCanvas canvas = new TestCanvas(platform);
+
+        canvas.render();
+        assertEquals(320, canvas.getFramebufferWidth());
+        assertEquals(240, canvas.getFramebufferHeight());
+
+        platform.framebufferWidth = 900;
+        platform.framebufferHeight = 600;
+        canvas.render();
+        assertEquals(900, canvas.getFramebufferWidth());
+        assertEquals(600, canvas.getFramebufferHeight());
+    }
+
+    @Test
+    void refreshesFallbackFramebufferSizeWhenGraphicsScaleChanges() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.reportsFramebufferSize = false;
+        ScaledTestCanvas canvas = new ScaledTestCanvas(platform, 201, 101, 1.5, 1.5);
+
+        canvas.render();
+        assertEquals(302, canvas.getFramebufferWidth());
+        assertEquals(152, canvas.getFramebufferHeight());
+
+        canvas.graphicsConfiguration = new TestGraphicsConfiguration(2.0, 2.0);
+        canvas.render();
+        assertEquals(402, canvas.getFramebufferWidth());
+        assertEquals(202, canvas.getFramebufferHeight());
+    }
 
     @Test
     void disposeCanvasDeletesContextBeforeDrawingSurface() {
@@ -296,12 +352,81 @@ class AWTGLCanvasLifecycleTest {
         }
     }
 
+    private static final class ScaledTestCanvas extends TestCanvas {
+        private final int width;
+        private final int height;
+        private GraphicsConfiguration graphicsConfiguration;
+
+        ScaledTestCanvas(PlatformGLCanvas platformCanvas, int width, int height, double scaleX, double scaleY) {
+            super(platformCanvas);
+            this.width = width;
+            this.height = height;
+            this.graphicsConfiguration = new TestGraphicsConfiguration(scaleX, scaleY);
+        }
+
+        @Override
+        public int getWidth() {
+            return width;
+        }
+
+        @Override
+        public int getHeight() {
+            return height;
+        }
+
+        @Override
+        public GraphicsConfiguration getGraphicsConfiguration() {
+            return graphicsConfiguration;
+        }
+    }
+
+    private static final class TestGraphicsConfiguration extends GraphicsConfiguration {
+        private final AffineTransform transform;
+
+        TestGraphicsConfiguration(double scaleX, double scaleY) {
+            transform = AffineTransform.getScaleInstance(scaleX, scaleY);
+        }
+
+        @Override
+        public GraphicsDevice getDevice() {
+            return null;
+        }
+
+        @Override
+        public ColorModel getColorModel() {
+            return ColorModel.getRGBdefault();
+        }
+
+        @Override
+        public ColorModel getColorModel(int transparency) {
+            return transparency == Transparency.OPAQUE ? ColorModel.getRGBdefault() : null;
+        }
+
+        @Override
+        public AffineTransform getDefaultTransform() {
+            return new AffineTransform(transform);
+        }
+
+        @Override
+        public AffineTransform getNormalizingTransform() {
+            return new AffineTransform();
+        }
+
+        @Override
+        public Rectangle getBounds() {
+            return new Rectangle();
+        }
+    }
+
     private static class RecordingPlatformCanvas implements PlatformGLCanvas {
         final List<String> calls = Collections.synchronizedList(new ArrayList<>());
         final CountDownLatch deleteCalled = new CountDownLatch(1);
         RuntimeException deleteFailure;
         long makeCurrentFailureContext = Long.MIN_VALUE;
         long makeCurrentExceptionContext = Long.MIN_VALUE;
+        boolean reportsFramebufferSize = true;
+        int framebufferWidth;
+        int framebufferHeight;
 
         @Override
         public long create(Canvas canvas, GLData data, GLData effective) {
@@ -342,6 +467,16 @@ class AWTGLCanvasLifecycleTest {
         @Override
         public boolean delayBeforeSwapNV(float seconds) {
             return false;
+        }
+
+        @Override
+        public boolean getFramebufferSize(int[] size) {
+            if (!reportsFramebufferSize) {
+                return false;
+            }
+            size[0] = framebufferWidth;
+            size[1] = framebufferHeight;
+            return true;
         }
 
         @Override

--- a/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
@@ -10,8 +10,56 @@ import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
 import java.awt.Dimension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.lwjgl.opengl.CGL.CGLDisable;
+import static org.lwjgl.opengl.CGL.CGLGetParameter;
+import static org.lwjgl.opengl.CGL.CGLIsEnabled;
+import static org.lwjgl.opengl.CGL.kCGLCESurfaceBackingSize;
+import static org.lwjgl.opengl.CGL.kCGLCPSurfaceBackingSize;
+import static org.lwjgl.opengl.CGL.kCGLNoError;
+
 @EnabledOnOs(OS.MAC)
 class MacOSXGLCanvasLifecycleTest {
+
+    @Test
+    void configuresInitialSurfaceBackingSizeBeforeInitGL() throws Exception {
+        FrameState state = showSingleCanvas();
+        try {
+            renderCanvases(state);
+            TestCanvas canvas = state.canvases[0];
+            assertTrue(canvas.surfaceBackingSizeEnabled);
+            assertEquals(canvas.getFramebufferWidth(), canvas.surfaceBackingWidth);
+            assertEquals(canvas.getFramebufferHeight(), canvas.surfaceBackingHeight);
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
+
+    @Test
+    void reassertsSurfaceBackingSizeOnEveryContextActivation() throws Exception {
+        FrameState state = showSingleCanvas();
+        try {
+            renderCanvases(state);
+            TestCanvas canvas = state.canvases[0];
+            canvas.runInContext(() -> assertEquals(
+                    kCGLNoError,
+                    CGLDisable(canvas.context, kCGLCESurfaceBackingSize)));
+
+            canvas.runInContext(() -> {
+                int[] enabled = new int[1];
+                assertEquals(kCGLNoError, CGLIsEnabled(canvas.context, kCGLCESurfaceBackingSize, enabled));
+                assertEquals(1, enabled[0]);
+
+                int[] size = new int[2];
+                assertEquals(kCGLNoError, CGLGetParameter(canvas.context, kCGLCPSurfaceBackingSize, size));
+                assertEquals(canvas.getFramebufferWidth(), size[0]);
+                assertEquals(canvas.getFramebufferHeight(), size[1]);
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
 
     @Test
     void createsMultipleCanvasesAfterDisposingPreviousWindow() throws Exception {
@@ -94,9 +142,21 @@ class MacOSXGLCanvasLifecycleTest {
     }
 
     private static class TestCanvas extends AWTGLCanvas {
+        boolean surfaceBackingSizeEnabled;
+        int surfaceBackingWidth;
+        int surfaceBackingHeight;
+
         @Override
         public void initGL() {
             GL.createCapabilities();
+            int[] enabled = new int[1];
+            assertEquals(kCGLNoError, CGLIsEnabled(context, kCGLCESurfaceBackingSize, enabled));
+            surfaceBackingSizeEnabled = enabled[0] != 0;
+
+            int[] size = new int[2];
+            assertEquals(kCGLNoError, CGLGetParameter(context, kCGLCPSurfaceBackingSize, size));
+            surfaceBackingWidth = size[0];
+            surfaceBackingHeight = size[1];
         }
 
         @Override


### PR DESCRIPTION
> [!NOTE]
> Follows #131, which has been merged.

Framebuffer dimensions were updated primarily by resize events. They could therefore be zero before the first `initGL()`, stale after a graphics-configuration or DPI change, and inaccurate when scaled AWT dimensions differed from the native drawable size.

Dimensions are now refreshed after making the context current and before every render while the JAWT drawing surface is locked. Windows queries the HWND client rectangle, Linux queries the X11 drawable geometry, and macOS reasserts and reads back the CGL backing size. Scaled component dimensions remain available as a fallback.

Tests cover initial dimensions before `initGL()`, updates between renders, native dimensions taking precedence, DPI changes without resizing, failure cleanup, and CGL backing-size reassertion. The full test suite passes.
