### PR TITLE
Update macOS OpenGL layer bounds dynamically

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -77,6 +77,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     public static final JAWT awt;
     private static final long objc_msgSend;
+    private static final long objc_autoreleasePoolPush;
+    private static final long objc_autoreleasePoolPop;
     private static final long NSOpenGLPixelFormat;
 
     static {
@@ -85,6 +87,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         if (!JAWT_GetAWT(awt))
             throw new AssertionError("GetAWT failed");
         objc_msgSend = ObjCRuntime.getLibrary().getFunctionAddress("objc_msgSend");
+        objc_autoreleasePoolPush = ObjCRuntime.getLibrary().getFunctionAddress("objc_autoreleasePoolPush");
+        objc_autoreleasePoolPop = ObjCRuntime.getLibrary().getFunctionAddress("objc_autoreleasePoolPop");
         NSOpenGLPixelFormat = objc_getClass("NSOpenGLPixelFormat");
     }
 
@@ -97,6 +101,10 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     private int framebufferWidth;
     private int framebufferHeight;
     private final int[] currentFramebufferSize = new int[2];
+    private int layerX;
+    private int layerY;
+    private int layerWidth;
+    private int layerHeight;
 
     @Override
     public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
@@ -120,20 +128,16 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
             try {
                 JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds, ds.GetDrawingSurfaceInfo());
                 try {
-                    // if the canvas is inside e.g. a JSplitPane, the dsi coordinates are wrong and need to be corrected
-                    int x = dsi.bounds().x();
-                    int y = dsi.bounds().y();
                     int width = dsi.bounds().width();
                     int height = dsi.bounds().height();
-                    JRootPane rootPane = SwingUtilities.getRootPane(canvas);
-                    if (rootPane != null) {
-                        Point point = SwingUtilities.convertPoint(canvas, new Point(), rootPane);
-                        x = point.x;
-                        y = rootPane.getHeight() - point.y - height;
-                    }
+                    int[] layerBounds = getLayerBounds(canvas, dsi.bounds().x(), dsi.bounds().y(), width, height);
                     FramebufferSizeUtil.getScaledSize(canvas, width, height, currentFramebufferSize);
                     this.framebufferWidth = currentFramebufferSize[0];
                     this.framebufferHeight = currentFramebufferSize[1];
+                    this.layerX = layerBounds[0];
+                    this.layerY = layerBounds[1];
+                    this.layerWidth = layerBounds[2];
+                    this.layerHeight = layerBounds[3];
 
                     //TODO: we don't really need 100
                     ByteBuffer attribsArray = ByteBuffer.allocateDirect(4 * 100).order(ByteOrder.nativeOrder());
@@ -212,7 +216,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                     long pixelFormat = invokePPP(NSOpenGLPixelFormat, sel_getUid("alloc"), objc_msgSend);
                     pixelFormat = invokePPPP(pixelFormat, sel_getUid("initWithAttributes:"), MemoryUtil.memAddress(attribsArray), objc_msgSend);
 
-                    view = createNSOpenGLView(pixelFormat, x, y, width, height);
+                    view = createNSOpenGLView(pixelFormat,
+                            layerBounds[0], layerBounds[1], layerBounds[2], layerBounds[3]);
                     // The surface layer belongs to the peer view rather than to the drawing surface info, but
                     // retain it so it stays alive until the context is deleted.
                     surfaceLayer = invokePPP(dsi.platformInfo(), sel_getUid("retain"), objc_msgSend);
@@ -263,16 +268,22 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                 true,
                 objc_msgSend);
 
-        // get layer from NSOpenGLView instance and set its auto resizing mask (kCALayerWidthSizable | kCALayerHeightSizable)
+        // get layer from NSOpenGLView instance
         // CALayer *layer = nsOpenGLView.layer;
         long openglViewLayer = JNI.invokePPJ(view,
                 ObjCRuntime.sel_getUid("layer"),
                 objc_msgSend);
 
-        // [layer setAutoresizingMask:(kCALayerWidthSizable | kCAHeightSizable)];
+        // The layer must not autoresize with the intermediate layer. Core Animation's autoresizing applies the
+        // superlayer's bounds *delta* to its sublayers, and the intermediate layer's frame is applied
+        // asynchronously on AppKit's main thread. Whenever that frame lands after this layer has been added, the
+        // intermediate layer grows from its default 0x0 to width x height, and kCALayerWidthSizable |
+        // kCALayerHeightSizable would add that same width/height to this layer, presenting it at twice its size.
+        // The canvas dimensions are known here and are reapplied by updateLayerBounds, so size the layer directly.
+        // [layer setAutoresizingMask:kCALayerNotSizable];
         JNI.callPPPV(openglViewLayer,
                 ObjCRuntime.sel_getUid("setAutoresizingMask:"),
-                18,
+                0,
                 objc_msgSend);
 
         // create intermediate layer and set its frame
@@ -284,7 +295,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         invokePPP(interLayer, sel_getUid("retain"), objc_msgSend);
 
         // [interLayer setFrame:CGRectMake(x, y, width, height)];
-        setOpenglViewLayersFrame(interLayer, new double[]{x, y, width, height});
+        setFrameOnMainThread(interLayer, x, y, width, height);
 
         // add NSOpenGLView's layer to the intermediate layer
         // [interLayer addSublayer:layer];
@@ -319,6 +330,38 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         invokePPP(invocation, sel_getUid("retain"), objc_msgSend);
         performSelectorOnMainThread(invocation, sel_getUid("invoke"), MemoryUtil.NULL);
         performSelectorOnMainThread(invocation, sel_getUid("release"), MemoryUtil.NULL);
+    }
+
+    /**
+     * Queues a {@code setFrame:} on AppKit's main thread. The target may be a CALayer or an NSView; both take a
+     * CGRect, so the same invocation is used for either.
+     */
+    private static void setFrameOnMainThread(long target, int x, int y, int width, int height) {
+        long autoreleasePool = invokeP(objc_autoreleasePoolPush);
+        try {
+            // Core Animation frame changes must be committed by AppKit's run loop. NSInvocation also copies the
+            // CGRect argument, so the temporary direct buffer can be released as soon as the mutation has been queued.
+            long setFrame = sel_getUid("setFrame:");
+            long methodSignature = invokePPPP(target, sel_getUid("methodSignatureForSelector:"), setFrame, objc_msgSend);
+            long invocation = invokePPPP(objc_getClass("NSInvocation"),
+                    sel_getUid("invocationWithMethodSignature:"), methodSignature, objc_msgSend);
+
+            invokePPPV(invocation, sel_getUid("setTarget:"), target, objc_msgSend);
+            invokePPPV(invocation, sel_getUid("setSelector:"), setFrame, objc_msgSend);
+
+            ByteBuffer frame = BufferUtils.createByteBuffer(4 * Double.BYTES).order(ByteOrder.nativeOrder());
+            frame.putDouble(0, x);
+            frame.putDouble(Double.BYTES, y);
+            frame.putDouble(2 * Double.BYTES, width);
+            frame.putDouble(3 * Double.BYTES, height);
+            JNI.callPPPPV(invocation, sel_getUid("setArgument:atIndex:"), memAddress(frame), 2, objc_msgSend);
+
+            invokePPP(invocation, sel_getUid("retain"), objc_msgSend);
+            performSelectorOnMainThread(invocation, sel_getUid("invoke"), MemoryUtil.NULL);
+            performSelectorOnMainThread(invocation, sel_getUid("release"), MemoryUtil.NULL);
+        } finally {
+            invokePV(autoreleasePool, objc_autoreleasePoolPop);
+        }
     }
 
     private static void performSelectorOnMainThread(long target, long selector, long argument) {
@@ -367,31 +410,6 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         }
     }
 
-    private static void setOpenglViewLayersFrame(long openglViewLayer, double[] frame) {
-        try (MemoryStack stack = MemoryStack.stackPush()) {
-            FFIType cgRect = createCGRectType(stack);
-            PointerBuffer argumentTypes = stack.pointers(
-                    ffi_type_pointer.address(), // CALayer*
-                    ffi_type_pointer.address(), // setFrame:
-                    cgRect.address());           // CGRect
-
-            FFICIF cif = FFICIF.malloc(stack);
-            int status = ffi_prep_cif(cif, FFI_DEFAULT_ABI, ffi_type_void, argumentTypes);
-            if (status != FFI_OK) {
-                throw new IllegalStateException("ffi_prep_cif failed: " + status);
-            }
-
-            DoubleBuffer frameValue = stack.doubles(frame[0], frame[1], frame[2], frame[3]);
-            PointerBuffer pointerValues = stack.pointers(openglViewLayer, ObjCRuntime.sel_getUid("setFrame:"));
-            PointerBuffer arguments = stack.pointers(
-                    memAddress(pointerValues, 0),
-                    memAddress(pointerValues, 1),
-                    memAddress(frameValue));
-
-            ffi_call(cif, objc_msgSend, null, arguments);
-        }
-    }
-
     private static FFIType createCGRectType(MemoryStack stack) {
         PointerBuffer elements = stack.mallocPointer(5);
         elements.put(ffi_type_double.address());
@@ -414,6 +432,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         long view = this.view;
         long surfaceLayer = this.surfaceLayer;
         this.view = 0L;
+        this.interLayer = 0L;
         this.surfaceLayer = 0L;
 
         // Keep teardown ordered behind any pending layer updates and run it on AppKit's main thread. Clearing an
@@ -454,11 +473,48 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                 }
                 this.framebufferWidth = Math.max(0, currentFramebufferSize[0]);
                 this.framebufferHeight = Math.max(0, currentFramebufferSize[1]);
+                int[] layerBounds = getLayerBounds(canvas, dsi.bounds().x(), dsi.bounds().y(), width, height);
+                updateLayerBounds(layerBounds);
             } finally {
                 JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
             }
         }
         return true;
+    }
+
+    private void updateLayerBounds(int[] bounds) {
+        if (bounds[0] == layerX && bounds[1] == layerY
+                && bounds[2] == layerWidth && bounds[3] == layerHeight) {
+            return;
+        }
+        boolean resized = bounds[2] != layerWidth || bounds[3] != layerHeight;
+        layerX = bounds[0];
+        layerY = bounds[1];
+        layerWidth = bounds[2];
+        layerHeight = bounds[3];
+        if (interLayer != 0L) {
+            setFrameOnMainThread(interLayer, layerX, layerY, layerWidth, layerHeight);
+        }
+        if (resized && view != 0L) {
+            // The OpenGL layer does not autoresize with the intermediate layer, so it has to follow the canvas
+            // explicitly. Resizing the view keeps NSOpenGLView's own drawable in step with its layer.
+            setFrameOnMainThread(view, 0, 0, layerWidth, layerHeight);
+            setFrameOnMainThread(invokePPP(view, sel_getUid("layer"), objc_msgSend),
+                    0, 0, layerWidth, layerHeight);
+        }
+    }
+
+    private static int[] getLayerBounds(Canvas canvas, int x, int y, int width, int height) {
+        // JAWT reports incorrect coordinates for canvases nested in containers such as JSplitPane.
+        // These component reads may occur off the EDT. A concurrent layout can yield one stale frame, but the bounds
+        // are sampled again on the next context activation and converge without blocking AppKit or AWT.
+        JRootPane rootPane = SwingUtilities.getRootPane(canvas);
+        if (rootPane != null) {
+            Point point = SwingUtilities.convertPoint(canvas, new Point(), rootPane);
+            x = point.x;
+            y = rootPane.getHeight() - point.y - height;
+        }
+        return new int[]{x, y, width, height};
     }
 
     @Override

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -1,6 +1,5 @@
 package org.lwjgl.opengl.awt;
 
-import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
@@ -321,9 +320,11 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         invokePPPV(invocation, sel_getUid("setTarget:"), layer, objc_msgSend);
         invokePPPV(invocation, sel_getUid("setSelector:"), setHidden, objc_msgSend);
 
-        ByteBuffer hiddenValue = BufferUtils.createByteBuffer(1);
-        hiddenValue.put(0, hidden ? (byte) 1 : 0);
-        JNI.callPPPPV(invocation, sel_getUid("setArgument:atIndex:"), memAddress(hiddenValue), 2, objc_msgSend);
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            ByteBuffer hiddenValue = stack.malloc(1);
+            hiddenValue.put(0, hidden ? (byte) 1 : 0);
+            JNI.callPPPPV(invocation, sel_getUid("setArgument:atIndex:"), memAddress(hiddenValue), 2, objc_msgSend);
+        }
 
         // Hierarchy notifications run on AWT's event thread, which AppKit may itself be waiting for. Queue the
         // mutation rather than introducing a synchronous AWT/AppKit cross-thread wait.
@@ -339,8 +340,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     private static void setFrameOnMainThread(long target, int x, int y, int width, int height) {
         long autoreleasePool = invokeP(objc_autoreleasePoolPush);
         try {
-            // Core Animation frame changes must be committed by AppKit's run loop. NSInvocation also copies the
-            // CGRect argument, so the temporary direct buffer can be released as soon as the mutation has been queued.
+            // Core Animation frame changes must be committed by AppKit's run loop. NSInvocation copies the CGRect
+            // argument during setArgument:atIndex:, so stack storage remains valid for the complete native read.
             long setFrame = sel_getUid("setFrame:");
             long methodSignature = invokePPPP(target, sel_getUid("methodSignatureForSelector:"), setFrame, objc_msgSend);
             long invocation = invokePPPP(objc_getClass("NSInvocation"),
@@ -349,12 +350,10 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
             invokePPPV(invocation, sel_getUid("setTarget:"), target, objc_msgSend);
             invokePPPV(invocation, sel_getUid("setSelector:"), setFrame, objc_msgSend);
 
-            ByteBuffer frame = BufferUtils.createByteBuffer(4 * Double.BYTES).order(ByteOrder.nativeOrder());
-            frame.putDouble(0, x);
-            frame.putDouble(Double.BYTES, y);
-            frame.putDouble(2 * Double.BYTES, width);
-            frame.putDouble(3 * Double.BYTES, height);
-            JNI.callPPPPV(invocation, sel_getUid("setArgument:atIndex:"), memAddress(frame), 2, objc_msgSend);
+            try (MemoryStack stack = MemoryStack.stackPush()) {
+                DoubleBuffer frame = stack.doubles(x, y, width, height);
+                JNI.callPPPPV(invocation, sel_getUid("setArgument:atIndex:"), memAddress(frame), 2, objc_msgSend);
+            }
 
             invokePPP(invocation, sel_getUid("retain"), objc_msgSend);
             performSelectorOnMainThread(invocation, sel_getUid("invoke"), MemoryUtil.NULL);
@@ -458,6 +457,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
             try {
                 int width = dsi.bounds().width();
                 int height = dsi.bounds().height();
+                int[] layerBounds = getLayerBounds(canvas, dsi.bounds().x(), dsi.bounds().y(), width, height);
+                updateLayerBounds(layerBounds);
                 FramebufferSizeUtil.getScaledSize(canvas, width, height, currentFramebufferSize);
                 int backingWidth = currentFramebufferSize[0];
                 int backingHeight = currentFramebufferSize[1];
@@ -473,8 +474,6 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                 }
                 this.framebufferWidth = Math.max(0, currentFramebufferSize[0]);
                 this.framebufferHeight = Math.max(0, currentFramebufferSize[1]);
-                int[] layerBounds = getLayerBounds(canvas, dsi.bounds().x(), dsi.bounds().y(), width, height);
-                updateLayerBounds(layerBounds);
             } finally {
                 JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
             }
@@ -504,15 +503,25 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         }
     }
 
-    private static int[] getLayerBounds(Canvas canvas, int x, int y, int width, int height) {
+    static int[] getLayerBounds(Canvas canvas, int x, int y, int width, int height) {
         // JAWT reports incorrect coordinates for canvases nested in containers such as JSplitPane.
-        // These component reads may occur off the EDT. A concurrent layout can yield one stale frame, but the bounds
-        // are sampled again on the next context activation and converge without blocking AppKit or AWT.
-        JRootPane rootPane = SwingUtilities.getRootPane(canvas);
-        if (rootPane != null) {
-            Point point = SwingUtilities.convertPoint(canvas, new Point(), rootPane);
-            x = point.x;
-            y = rootPane.getHeight() - point.y - height;
+        // Do not use SwingUtilities.convertPoint here: rendering holds the lifecycle lock, while screen-coordinate
+        // conversion may acquire AWT's tree lock in the opposite order to removeNotify. Reading the hierarchy directly
+        // is intentionally lock-free. A concurrent layout can yield one stale frame, but the next activation converges.
+        int rootX = 0;
+        int rootY = 0;
+        Component child = canvas;
+        Container parent = canvas.getParent();
+        while (parent != null) {
+            rootX += child.getX();
+            rootY += child.getY();
+            if (parent instanceof JRootPane) {
+                x = rootX;
+                y = parent.getHeight() - rootY - height;
+                break;
+            }
+            child = parent;
+            parent = parent.getParent();
         }
         return new int[]{x, y, width, height};
     }

--- a/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
@@ -3,16 +3,42 @@ package org.lwjgl.opengl.awt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.lwjgl.PointerBuffer;
 import org.lwjgl.opengl.GL;
+import org.lwjgl.system.JNI;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.system.Platform;
+import org.lwjgl.system.libffi.FFICIF;
+import org.lwjgl.system.libffi.FFIType;
+import org.lwjgl.system.macosx.ObjCRuntime;
 
 import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JRootPane;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
 import java.awt.Dimension;
+import java.awt.Point;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 
+import static java.nio.ByteOrder.nativeOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.lwjgl.opengl.CGL.CGLDisable;
+import static org.lwjgl.system.MemoryUtil.memAddress;
+import static org.lwjgl.system.libffi.LibFFI.FFI_DEFAULT_ABI;
+import static org.lwjgl.system.libffi.LibFFI.FFI_OK;
+import static org.lwjgl.system.libffi.LibFFI.FFI_TYPE_STRUCT;
+import static org.lwjgl.system.libffi.LibFFI.ffi_call;
+import static org.lwjgl.system.libffi.LibFFI.ffi_prep_cif;
+import static org.lwjgl.system.libffi.LibFFI.ffi_type_double;
+import static org.lwjgl.system.libffi.LibFFI.ffi_type_pointer;
+import static org.lwjgl.system.libffi.LibFFI.ffi_type_void;
+import static org.lwjgl.system.macosx.ObjCRuntime.sel_getUid;
 import static org.lwjgl.opengl.CGL.CGLGetParameter;
 import static org.lwjgl.opengl.CGL.CGLIsEnabled;
 import static org.lwjgl.opengl.CGL.kCGLCESurfaceBackingSize;
@@ -56,6 +82,71 @@ class MacOSXGLCanvasLifecycleTest {
                 assertEquals(canvas.getFramebufferWidth(), size[0]);
                 assertEquals(canvas.getFramebufferHeight(), size[1]);
             });
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
+
+    @Test
+    void clearsIntermediateLayerReferenceWhenCanvasIsDisposed() throws Exception {
+        FrameState state = showSingleCanvas();
+        boolean disposed = false;
+        try {
+            renderCanvases(state);
+            TestCanvas canvas = state.canvases[0];
+            assertNotEquals(0L, getIntermediateLayer(canvas));
+
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+            disposed = true;
+            assertEquals(0L, getIntermediateLayer(canvas));
+        } finally {
+            if (!disposed) {
+                SwingUtilities.invokeAndWait(state.frame::dispose);
+            }
+        }
+    }
+
+    @Test
+    void updatesNativeLayerFrameWhenCanvasMovesInsideRootPane() throws Exception {
+        FrameState state = showMovableCanvas();
+        try {
+            renderCanvases(state);
+
+            double[] initialFrame = expectedLayerFrame(state.canvases[0]);
+            assertLayerFrameEventually(state.canvases[0], initialFrame);
+
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = state.canvases[0];
+                canvas.setLocation(canvas.getX() + 80, canvas.getY());
+            });
+
+            double[] movedFrame = expectedLayerFrame(state.canvases[0]);
+            assertNotEquals(initialFrame[0], movedFrame[0], "The test must move the canvas in its root pane");
+            long layer = getIntermediateLayer(state.canvases[0]);
+            SwingUtilities.invokeAndWait(() -> writeLayerFrame(layer, initialFrame));
+            assertLayerFrameEventually(state.canvases[0], initialFrame);
+
+            renderCanvases(state);
+            assertLayerFrameEventually(state.canvases[0], movedFrame);
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
+
+    @Test
+    void keepsOpenGLLayerAtCanvasSize() throws Exception {
+        FrameState state = showMovableCanvas();
+        try {
+            renderCanvases(state);
+            TestCanvas canvas = state.canvases[0];
+            assertEquals(0L, readAutoresizingMask(getOpenGLLayer(canvas)));
+            assertOpenGLLayerFrameEventually(canvas, new double[]{0.0, 0.0, 160.0, 120.0});
+
+            SwingUtilities.invokeAndWait(() -> canvas.setSize(240, 160));
+            renderCanvases(state);
+
+            assertEquals(0L, readAutoresizingMask(getOpenGLLayer(canvas)));
+            assertOpenGLLayerFrameEventually(canvas, new double[]{0.0, 0.0, 240.0, 160.0});
         } finally {
             SwingUtilities.invokeAndWait(state.frame::dispose);
         }
@@ -117,6 +208,24 @@ class MacOSXGLCanvasLifecycleTest {
         return result[0];
     }
 
+    private static FrameState showMovableCanvas() throws Exception {
+        FrameState[] result = new FrameState[1];
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame("macOS dynamic OpenGL layer bounds");
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+
+            TestCanvas canvas = createCanvas();
+            JPanel content = new JPanel(null);
+            canvas.setBounds(40, 40, 160, 120);
+            content.add(canvas);
+            frame.setContentPane(content);
+            frame.setSize(480, 280);
+            frame.setVisible(true);
+            result[0] = new FrameState(frame, new TestCanvas[]{canvas});
+        });
+        return result[0];
+    }
+
     private static TestCanvas createCanvas() {
         TestCanvas canvas = new TestCanvas();
         canvas.setPreferredSize(new Dimension(160, 120));
@@ -129,6 +238,151 @@ class MacOSXGLCanvasLifecycleTest {
                 canvas.render();
             }
         });
+    }
+
+    private static double[] expectedLayerFrame(TestCanvas canvas) throws Exception {
+        double[][] result = new double[1][];
+        SwingUtilities.invokeAndWait(() -> {
+            JRootPane rootPane = SwingUtilities.getRootPane(canvas);
+            Point point = SwingUtilities.convertPoint(canvas, new Point(), rootPane);
+            result[0] = new double[]{
+                    point.x,
+                    rootPane.getHeight() - point.y - canvas.getHeight(),
+                    canvas.getWidth(),
+                    canvas.getHeight()
+            };
+        });
+        return result[0];
+    }
+
+    private static void assertLayerFrameEventually(TestCanvas canvas, double[] expected) throws Exception {
+        long deadline = System.nanoTime() + 5_000_000_000L;
+        long layer = getIntermediateLayer(canvas);
+        double[] actual;
+        do {
+            actual = readLayerFrame(layer);
+            if (framesEqual(expected, actual)) {
+                return;
+            }
+            Thread.sleep(10L);
+        } while (System.nanoTime() < deadline);
+        fail("Expected native layer frame " + formatFrame(expected) + " but was " + formatFrame(actual));
+    }
+
+    private static void assertOpenGLLayerFrameEventually(TestCanvas canvas, double[] expected) throws Exception {
+        long deadline = System.nanoTime() + 5_000_000_000L;
+        double[] actual;
+        do {
+            actual = readLayerFrame(getOpenGLLayer(canvas));
+            if (framesEqual(expected, actual)) {
+                return;
+            }
+            Thread.sleep(10L);
+        } while (System.nanoTime() < deadline);
+        fail("Expected native OpenGL layer frame " + formatFrame(expected) + " but was " + formatFrame(actual));
+    }
+
+    private static long getIntermediateLayer(TestCanvas canvas) throws Exception {
+        return getPlatformField(canvas, "interLayer");
+    }
+
+    private static long getOpenGLLayer(TestCanvas canvas) throws Exception {
+        long view = getPlatformField(canvas, "view");
+        long objcMsgSend = ObjCRuntime.getLibrary().getFunctionAddress("objc_msgSend");
+        return JNI.invokePPP(view, sel_getUid("layer"), objcMsgSend);
+    }
+
+    private static long getPlatformField(TestCanvas canvas, String name) throws Exception {
+        Field field = PlatformMacOSXGLCanvas.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.getLong(canvas.platformCanvas);
+    }
+
+    private static long readAutoresizingMask(long layer) {
+        long objcMsgSend = ObjCRuntime.getLibrary().getFunctionAddress("objc_msgSend");
+        return JNI.invokePPP(layer, sel_getUid("autoresizingMask"), objcMsgSend);
+    }
+
+    private static double[] readLayerFrame(long layer) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            FFIType cgRect = createCGRectType(stack);
+            PointerBuffer argumentTypes = stack.pointers(
+                    ffi_type_pointer.address(),
+                    ffi_type_pointer.address());
+
+            FFICIF cif = FFICIF.malloc(stack);
+            int status = ffi_prep_cif(cif, FFI_DEFAULT_ABI, cgRect, argumentTypes);
+            if (status != FFI_OK) {
+                throw new IllegalStateException("ffi_prep_cif failed: " + status);
+            }
+
+            PointerBuffer pointerValues = stack.pointers(layer, sel_getUid("frame"));
+            PointerBuffer arguments = stack.pointers(
+                    memAddress(pointerValues, 0),
+                    memAddress(pointerValues, 1));
+            ByteBuffer frame = stack.malloc(4 * Double.BYTES).order(nativeOrder());
+            Platform.Architecture architecture = Platform.getArchitecture();
+            // Intel macOS returns a CGRect indirectly; arm64 uses the ordinary Objective-C message entry point.
+            String messageFunction = architecture == Platform.Architecture.X64
+                    || architecture == Platform.Architecture.X86
+                    ? "objc_msgSend_stret"
+                    : "objc_msgSend";
+            ffi_call(cif, ObjCRuntime.getLibrary().getFunctionAddress(messageFunction), frame, arguments);
+            return new double[]{
+                    frame.getDouble(0),
+                    frame.getDouble(Double.BYTES),
+                    frame.getDouble(2 * Double.BYTES),
+                    frame.getDouble(3 * Double.BYTES)
+            };
+        }
+    }
+
+    private static void writeLayerFrame(long layer, double[] frame) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            FFIType cgRect = createCGRectType(stack);
+            PointerBuffer argumentTypes = stack.pointers(
+                    ffi_type_pointer.address(),
+                    ffi_type_pointer.address(),
+                    cgRect.address());
+
+            FFICIF cif = FFICIF.malloc(stack);
+            int status = ffi_prep_cif(cif, FFI_DEFAULT_ABI, ffi_type_void, argumentTypes);
+            if (status != FFI_OK) {
+                throw new IllegalStateException("ffi_prep_cif failed: " + status);
+            }
+
+            java.nio.DoubleBuffer frameValue = stack.doubles(frame[0], frame[1], frame[2], frame[3]);
+            PointerBuffer pointerValues = stack.pointers(layer, sel_getUid("setFrame:"));
+            PointerBuffer arguments = stack.pointers(
+                    memAddress(pointerValues, 0),
+                    memAddress(pointerValues, 1),
+                    memAddress(frameValue));
+            ffi_call(cif, ObjCRuntime.getLibrary().getFunctionAddress("objc_msgSend"), null, arguments);
+        }
+    }
+
+    private static FFIType createCGRectType(MemoryStack stack) {
+        PointerBuffer elements = stack.mallocPointer(5);
+        elements.put(ffi_type_double.address());
+        elements.put(ffi_type_double.address());
+        elements.put(ffi_type_double.address());
+        elements.put(ffi_type_double.address());
+        elements.put(MemoryUtil.NULL);
+        elements.flip();
+        return FFIType.calloc(stack).type(FFI_TYPE_STRUCT).elements(elements);
+    }
+
+    private static boolean framesEqual(double[] expected, double[] actual) {
+        for (int i = 0; i < expected.length; i++) {
+            if (Math.abs(expected[i] - actual[i]) > 0.01) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String formatFrame(double[] frame) {
+        return "[" + frame[0] + ", " + frame[1] + ", " + frame[2] + ", " + frame[3] + "]";
     }
 
     private static class FrameState {

--- a/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
@@ -18,7 +18,9 @@ import javax.swing.JPanel;
 import javax.swing.JRootPane;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
+import java.awt.Canvas;
 import java.awt.Dimension;
+import java.awt.IllegalComponentStateException;
 import java.awt.Point;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -47,6 +49,29 @@ import static org.lwjgl.opengl.CGL.kCGLNoError;
 
 @EnabledOnOs(OS.MAC)
 class MacOSXGLCanvasLifecycleTest {
+
+    @Test
+    void computesNestedLayerBoundsWithoutScreenCoordinateLookup() {
+        JRootPane rootPane = new JRootPane();
+        rootPane.setSize(500, 400);
+        JPanel outer = new JPanel(null);
+        outer.setBounds(17, 29, 400, 300);
+        JPanel inner = new JPanel(null);
+        inner.setBounds(31, 43, 300, 200);
+        CanvasWithoutScreenCoordinates canvas = new CanvasWithoutScreenCoordinates();
+        canvas.setBounds(47, 53, 160, 120);
+        inner.add(canvas);
+        outer.add(inner);
+        rootPane.getContentPane().setLayout(null);
+        rootPane.getContentPane().add(outer);
+
+        int[] bounds = PlatformMacOSXGLCanvas.getLayerBounds(canvas, 0, 0, 160, 120);
+
+        assertEquals(95, bounds[0]);
+        assertEquals(155, bounds[1]);
+        assertEquals(160, bounds[2]);
+        assertEquals(120, bounds[3]);
+    }
 
     @Test
     void configuresInitialSurfaceBackingSizeBeforeInitGL() throws Exception {
@@ -416,6 +441,13 @@ class MacOSXGLCanvasLifecycleTest {
         @Override
         public void paintGL() {
             swapBuffers();
+        }
+    }
+
+    private static final class CanvasWithoutScreenCoordinates extends Canvas {
+        @Override
+        public Point getLocationOnScreen() {
+            throw new IllegalComponentStateException("Screen-coordinate lookup must not be used");
         }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Follows #132 and #131, which have been merged.

The macOS intermediate layer frame was initialized only when the context was created. Moving or resizing a canvas inside a split pane or another container could therefore leave the native layer at stale coordinates, causing displaced, clipped, or incorrectly scaled rendering.

The current root-pane-relative bounds are now recomputed during context activation and applied asynchronously on AppKit's main thread. The NSOpenGLView and its layer are explicitly resized, Core Animation autoresizing is disabled to prevent double scaling, and native layer lifetime and autorelease handling are tightened.

Tests cover nested-container coordinate calculation, movement and resizing after context creation, correct OpenGL layer sizing, and disposal of the intermediate layer. The full test suite passes.
