### PR TITLE
Complete macOS GLData support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,7 +177,8 @@ jobs:
           architecture: ${{ matrix.java_architecture }}
           cache: maven
       - name: Build with Maven
-        run: ./mvnw -B test
+        # Hosted runners cannot retain macOS 15's private-window-picker authorization between jobs.
+        run: ./mvnw -B -Dlwjgl3.awt.robotScreenshots=off test
       - name: Upload Images
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ Support for Vulkan:
 _Note about compatibility_:
 The minimum macOS version for OpenGL is 10.5, and the minimum for Vulkan is 10.11, since Vulkan runs on top of the Metal API introduced in that version.
 
+### macOS compositor screenshot tests
+
+The end-to-end screenshot tests use `java.awt.Robot`, which requires Screen & System Audio Recording permission on
+macOS. They are disabled there by default so unattended builds never open macOS privacy UI. On a logged-in Mac where
+the process already has permission, require and run them with:
+
+```shell
+./mvnw -Pmacos-robot-screenshots test
+```
+
+The profile checks the normal screen-capture permission without requesting it and fails before attempting capture when
+it is unavailable. On macOS 15 and later, Apple's separate private-window-picker bypass authorization must also have
+been allowed already; macOS exposes no API that can preflight that authorization. Ordinary framebuffer-based
+screenshot tests continue to run on macOS without this profile.
+
 ## How to use
 Full code samples:
 - [AWTTest](/test/org/lwjgl/opengl/awt/AWTTest.java)

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 		<maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
 		<maven-source-plugin.version>3.4.0</maven-source-plugin.version>
 		<buildnumber-maven-plugin.version>3.3.0</buildnumber-maven-plugin.version>
+		<lwjgl3.awt.robotScreenshots>off</lwjgl3.awt.robotScreenshots>
 	</properties>
 	<profiles>
 		<profile>
@@ -175,6 +176,13 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>macos-robot-screenshots</id>
+			<properties>
+				<!-- Use only in a logged-in macOS session that already has Screen Recording permission. -->
+				<lwjgl3.awt.robotScreenshots>required</lwjgl3.awt.robotScreenshots>
+			</properties>
+		</profile>
+		<profile>
 			<id>jdk9</id>
 			<activation>
 				<jdk>[9,)</jdk>
@@ -295,6 +303,9 @@
 					<!-- A windowing deadlock would otherwise hang until the CI job times out. Fail fast
 					     instead: surefire dumps the forked VM's stack traces when this elapses. -->
 					<forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
+					<systemPropertyVariables>
+						<lwjgl3.awt.robotScreenshots>${lwjgl3.awt.robotScreenshots}</lwjgl3.awt.robotScreenshots>
+					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/org/lwjgl/opengl/awt/MacOSXGLDataUtil.java
+++ b/src/org/lwjgl/opengl/awt/MacOSXGLDataUtil.java
@@ -1,0 +1,170 @@
+package org.lwjgl.opengl.awt;
+
+import java.awt.AWTException;
+import java.util.ArrayList;
+import java.util.List;
+
+final class MacOSXGLDataUtil {
+    static final int NS_OPENGL_PFA_DOUBLE_BUFFER = 5;
+    static final int NS_OPENGL_PFA_STEREO = 6;
+    static final int NS_OPENGL_PFA_COLOR_SIZE = 8;
+    static final int NS_OPENGL_PFA_ALPHA_SIZE = 11;
+    static final int NS_OPENGL_PFA_DEPTH_SIZE = 12;
+    static final int NS_OPENGL_PFA_STENCIL_SIZE = 13;
+    static final int NS_OPENGL_PFA_ACCUM_SIZE = 14;
+    static final int NS_OPENGL_PFA_SAMPLE_BUFFERS = 55;
+    static final int NS_OPENGL_PFA_SAMPLES = 56;
+    static final int NS_OPENGL_PFA_COLOR_FLOAT = 58;
+    static final int NS_OPENGL_PFA_ACCELERATED = 73;
+    static final int NS_OPENGL_PFA_CLOSEST_POLICY = 74;
+    static final int NS_OPENGL_PFA_OPENGL_PROFILE = 99;
+
+    static final int NS_OPENGL_PROFILE_LEGACY = 0x1000;
+    static final int NS_OPENGL_PROFILE_3_2_CORE = 0x3200;
+    static final int NS_OPENGL_PROFILE_4_1_CORE = 0x4100;
+
+    private MacOSXGLDataUtil() {
+    }
+
+    static PixelFormatSelection choosePixelFormat(GLData data, PixelFormatFactory factory) throws AWTException {
+        List<int[]> candidates = createPixelFormatCandidates(data);
+        for (int[] candidate : candidates) {
+            long pixelFormat = factory.create(candidate);
+            if (pixelFormat != 0L) {
+                return new PixelFormatSelection(pixelFormat, candidate);
+            }
+        }
+        throw new AWTException("No compatible macOS OpenGL pixel format found after "
+                + candidates.size() + " attempts");
+    }
+
+    static List<int[]> createPixelFormatCandidates(GLData data) {
+        List<int[]> candidates = new ArrayList<>();
+        boolean includeSamples = data.samples > 0;
+        boolean includeAccumulation = accumulatorSize(data) > 0;
+        boolean includeStereo = data.stereo;
+        boolean includeFloat = data.pixelFormatFloat;
+        candidates.add(createPixelFormatAttributes(data, includeSamples, includeAccumulation,
+                includeStereo, includeFloat, true));
+
+        // Relax cumulatively from the most to the least exotic attribute. Dropping stereo and floating-point color
+        // first preserves commonly supported requests such as multisampling whenever possible.
+        if (includeStereo) {
+            includeStereo = false;
+            candidates.add(createPixelFormatAttributes(data, includeSamples, includeAccumulation,
+                    false, includeFloat, true));
+        }
+        if (includeFloat) {
+            includeFloat = false;
+            candidates.add(createPixelFormatAttributes(data, includeSamples, includeAccumulation,
+                    includeStereo, false, true));
+        }
+        if (includeAccumulation) {
+            includeAccumulation = false;
+            candidates.add(createPixelFormatAttributes(data, includeSamples, false,
+                    includeStereo, includeFloat, true));
+        }
+        if (includeSamples) {
+            includeSamples = false;
+            candidates.add(createPixelFormatAttributes(data, false, includeAccumulation,
+                    includeStereo, includeFloat, true));
+        }
+        candidates.add(createPixelFormatAttributes(data, false, false, false, false, false));
+        return candidates;
+    }
+
+    static int[] createPixelFormatAttributes(GLData data, boolean includeOptional, boolean accelerated) {
+        return createPixelFormatAttributes(data, includeOptional && data.samples > 0,
+                includeOptional && accumulatorSize(data) > 0,
+                includeOptional && data.stereo,
+                includeOptional && data.pixelFormatFloat,
+                accelerated);
+    }
+
+    private static int[] createPixelFormatAttributes(GLData data, boolean includeSamples,
+            boolean includeAccumulation, boolean includeStereo, boolean includeFloat, boolean accelerated) {
+        List<Integer> attributes = new ArrayList<>();
+        if (accelerated) {
+            attributes.add(NS_OPENGL_PFA_ACCELERATED);
+        }
+        attributes.add(NS_OPENGL_PFA_CLOSEST_POLICY);
+        if (data.doubleBuffer) {
+            attributes.add(NS_OPENGL_PFA_DOUBLE_BUFFER);
+        }
+        if (includeStereo) {
+            attributes.add(NS_OPENGL_PFA_STEREO);
+        }
+        if (includeFloat) {
+            attributes.add(NS_OPENGL_PFA_COLOR_FLOAT);
+        }
+
+        int accumSize = accumulatorSize(data);
+        if (includeAccumulation) {
+            addValue(attributes, NS_OPENGL_PFA_ACCUM_SIZE, accumSize);
+        }
+
+        int colorSize = data.redSize + data.greenSize + data.blueSize + data.alphaSize;
+        if (colorSize == 0) {
+            colorSize = 32;
+        } else if (colorSize < 15) {
+            colorSize = 15;
+        }
+        if (includeFloat && colorSize < 64) {
+            colorSize = 64;
+        }
+        addValue(attributes, NS_OPENGL_PFA_COLOR_SIZE, colorSize);
+        addValue(attributes, NS_OPENGL_PFA_ALPHA_SIZE, data.alphaSize);
+        addValue(attributes, NS_OPENGL_PFA_DEPTH_SIZE, data.depthSize);
+        addValue(attributes, NS_OPENGL_PFA_STENCIL_SIZE, data.stencilSize);
+
+        if (includeSamples) {
+            addValue(attributes, NS_OPENGL_PFA_SAMPLE_BUFFERS, 1);
+            addValue(attributes, NS_OPENGL_PFA_SAMPLES, data.samples);
+        }
+
+        addValue(attributes, NS_OPENGL_PFA_OPENGL_PROFILE, profileAttribute(data));
+        attributes.add(0);
+
+        int[] result = new int[attributes.size()];
+        for (int i = 0; i < attributes.size(); i++) {
+            result[i] = attributes.get(i);
+        }
+        return result;
+    }
+
+    static int profileAttribute(GLData data) {
+        if (data.profile == GLData.Profile.COMPATIBILITY) {
+            return NS_OPENGL_PROFILE_LEGACY;
+        }
+        if (data.majorVersion >= 4) {
+            return NS_OPENGL_PROFILE_4_1_CORE;
+        }
+        if (data.profile == GLData.Profile.CORE || data.majorVersion >= 3) {
+            return NS_OPENGL_PROFILE_3_2_CORE;
+        }
+        return NS_OPENGL_PROFILE_LEGACY;
+    }
+
+    private static int accumulatorSize(GLData data) {
+        return data.accumRedSize + data.accumGreenSize + data.accumBlueSize + data.accumAlphaSize;
+    }
+
+    private static void addValue(List<Integer> attributes, int attribute, int value) {
+        attributes.add(attribute);
+        attributes.add(value);
+    }
+
+    interface PixelFormatFactory {
+        long create(int[] attributes);
+    }
+
+    static final class PixelFormatSelection {
+        final long pixelFormat;
+        final int[] attributes;
+
+        PixelFormatSelection(long pixelFormat, int[] attributes) {
+            this.pixelFormat = pixelFormat;
+            this.attributes = attributes;
+        }
+    }
+}

--- a/src/org/lwjgl/opengl/awt/MacOSXGLDataUtil.java
+++ b/src/org/lwjgl/opengl/awt/MacOSXGLDataUtil.java
@@ -26,6 +26,40 @@ final class MacOSXGLDataUtil {
     private MacOSXGLDataUtil() {
     }
 
+    static void validateAttributes(GLData data) throws AWTException {
+        GLUtil.validateAttributes(data);
+        if (data.api != GLData.API.GL) {
+            throw new AWTException("macOS NSOpenGL does not support OpenGL ES contexts");
+        }
+        if (data.shareContext != null) {
+            throw new AWTException("macOS NSOpenGL context sharing is not supported");
+        }
+        if (data.debug) {
+            throw new AWTException("macOS NSOpenGL debug contexts are not supported");
+        }
+        if (data.sRGB) {
+            throw new AWTException("macOS NSOpenGL sRGB pixel formats are not supported");
+        }
+        if (data.contextReleaseBehavior != null) {
+            throw new AWTException("macOS NSOpenGL context release behavior is not supported");
+        }
+        if (data.colorSamplesNV > 0) {
+            throw new AWTException("macOS NSOpenGL coverage sampling is not supported");
+        }
+        if (data.swapGroupNV > 0 || data.swapBarrierNV > 0) {
+            throw new AWTException("macOS NSOpenGL swap groups and barriers are not supported");
+        }
+        if (data.robustness) {
+            throw new AWTException("macOS NSOpenGL robustness contexts are not supported");
+        }
+        if (data.profile == GLData.Profile.COMPATIBILITY) {
+            throw new AWTException("macOS NSOpenGL does not support compatibility profiles newer than OpenGL 2.1");
+        }
+        if (data.majorVersion > 4 || (data.majorVersion == 4 && data.minorVersion > 1)) {
+            throw new AWTException("macOS NSOpenGL supports OpenGL versions up to 4.1");
+        }
+    }
+
     static PixelFormatSelection choosePixelFormat(GLData data, PixelFormatFactory factory) throws AWTException {
         List<int[]> candidates = createPixelFormatCandidates(data);
         for (int[] candidate : candidates) {
@@ -136,7 +170,7 @@ final class MacOSXGLDataUtil {
         if (data.profile == GLData.Profile.COMPATIBILITY) {
             return NS_OPENGL_PROFILE_LEGACY;
         }
-        if (data.majorVersion >= 4) {
+        if (data.majorVersion >= 4 || (data.majorVersion == 3 && data.minorVersion > 2)) {
             return NS_OPENGL_PROFILE_4_1_CORE;
         }
         if (data.profile == GLData.Profile.CORE || data.majorVersion >= 3) {

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -1,6 +1,15 @@
 package org.lwjgl.opengl.awt;
 
 import org.lwjgl.PointerBuffer;
+import org.lwjgl.opengl.ARBRobustness;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL30;
+import org.lwjgl.opengl.GL32;
+import org.lwjgl.opengl.GL43;
+import org.lwjgl.system.APIUtil;
+import org.lwjgl.system.APIUtil.APIVersion;
+import org.lwjgl.system.Checks;
 import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
@@ -15,7 +24,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.HierarchyEvent;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
 import java.nio.IntBuffer;
 
@@ -65,75 +73,95 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     @Override
     public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
-        GLUtil.validateAttributes(attribs);
-        if (attribs.api != GLData.API.GL) {
-            throw new AWTException("macOS NSOpenGL does not support OpenGL ES contexts");
-        }
+        MacOSXGLDataUtil.validateAttributes(attribs);
         this.canvas = canvas;
-        if (!hierarchyListenerAdded) {
-            canvas.addHierarchyListener(e -> {
-                // if the canvas, or a parent component is hidden/shown, we must update the hidden state of the layer
-                if (view != 0L && (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) > 0) {
-                    long layer = invokePPP(view, sel_getUid("layer"), objc_msgSend);
-                    setLayerHiddenOnMainThread(layer, !e.getChanged().isShowing());
-                }
-            });
-            hierarchyListenerAdded = true;
-        }
-        long context;
-        JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         try {
-            int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
-            if ((lock & JAWT_LOCK_ERROR) != 0)
-                throw new AWTException("JAWT_DrawingSurface_Lock() failed");
+            if (!hierarchyListenerAdded) {
+                canvas.addHierarchyListener(e -> {
+                    // if the canvas, or a parent component is hidden/shown, we must update the hidden state of the layer
+                    if (view != 0L && (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) > 0) {
+                        long layer = invokePPP(view, sel_getUid("layer"), objc_msgSend);
+                        setLayerHiddenOnMainThread(layer, !e.getChanged().isShowing());
+                    }
+                });
+                hierarchyListenerAdded = true;
+            }
+            long context;
+            JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
+            if (ds == null) {
+                throw new AWTException("Failed to get JAWT drawing surface");
+            }
             try {
-                JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds, ds.GetDrawingSurfaceInfo());
+                int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
+                if ((lock & JAWT_LOCK_ERROR) != 0) {
+                    throw new AWTException("JAWT_DrawingSurface_Lock() failed");
+                }
                 try {
-                    int width = dsi.bounds().width();
-                    int height = dsi.bounds().height();
-                    int[] layerBounds = getLayerBounds(canvas, dsi.bounds().x(), dsi.bounds().y(), width, height);
-                    FramebufferSizeUtil.getScaledSize(canvas, width, height, currentFramebufferSize);
-                    this.framebufferWidth = currentFramebufferSize[0];
-                    this.framebufferHeight = currentFramebufferSize[1];
-                    this.layerX = layerBounds[0];
-                    this.layerY = layerBounds[1];
-                    this.layerWidth = layerBounds[2];
-                    this.layerHeight = layerBounds[3];
-
-                    MacOSXGLDataUtil.PixelFormatSelection selection =
-                            MacOSXGLDataUtil.choosePixelFormat(attribs, PlatformMacOSXGLCanvas::createPixelFormat);
-                    long pixelFormat = selection.pixelFormat;
+                    JAWTDrawingSurfaceInfo dsi =
+                            JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds, ds.GetDrawingSurfaceInfo());
+                    if (dsi == null) {
+                        throw new AWTException("Failed to get JAWT drawing surface information");
+                    }
                     try {
-                        view = createNSOpenGLView(pixelFormat,
-                                layerBounds[0], layerBounds[1], layerBounds[2], layerBounds[3]);
-                        // The surface layer belongs to the peer view rather than to the drawing surface info, but
-                        // retain it so it stays alive until the context is deleted.
-                        surfaceLayer = invokePPP(dsi.platformInfo(), sel_getUid("retain"), objc_msgSend);
-                        long openGLContext = invokePPP(view, sel_getUid("openGLContext"), objc_msgSend);
-                        context = invokePPP(openGLContext, sel_getUid("CGLContextObj"), objc_msgSend);
-                        if (context == 0L) {
-                            throw new AWTException("NSOpenGLView returned no OpenGL context");
+                        int width = dsi.bounds().width();
+                        int height = dsi.bounds().height();
+                        int[] layerBounds = getLayerBounds(canvas, dsi.bounds().x(), dsi.bounds().y(), width, height);
+                        FramebufferSizeUtil.getScaledSize(canvas, width, height, currentFramebufferSize);
+                        this.framebufferWidth = currentFramebufferSize[0];
+                        this.framebufferHeight = currentFramebufferSize[1];
+                        this.layerX = layerBounds[0];
+                        this.layerY = layerBounds[1];
+                        this.layerWidth = layerBounds[2];
+                        this.layerHeight = layerBounds[3];
+
+                        MacOSXGLDataUtil.PixelFormatSelection selection =
+                                MacOSXGLDataUtil.choosePixelFormat(attribs, PlatformMacOSXGLCanvas::createPixelFormat);
+                        long pixelFormat = selection.pixelFormat;
+                        try {
+                            view = createNSOpenGLView(pixelFormat,
+                                    layerBounds[0], layerBounds[1], layerBounds[2], layerBounds[3]);
+                            // The surface layer belongs to the peer view rather than to the drawing surface info, but
+                            // retain it so it stays alive until the context is deleted.
+                            surfaceLayer = invokePPP(dsi.platformInfo(), sel_getUid("retain"), objc_msgSend);
+                            if (surfaceLayer == 0L) {
+                                throw new AWTException("JAWT returned no macOS surface layer");
+                            }
+                            long openGLContext = invokePPP(view, sel_getUid("openGLContext"), objc_msgSend);
+                            if (openGLContext == 0L) {
+                                throw new AWTException("NSOpenGLView returned no NSOpenGLContext");
+                            }
+                            context = invokePPP(openGLContext, sel_getUid("CGLContextObj"), objc_msgSend);
+                            if (context == 0L) {
+                                throw new AWTException("NSOpenGLView returned no OpenGL context");
+                            }
+                            this.context = context;
+                            configureSwapInterval(context, attribs.swapInterval);
+                            populateEffectiveData(context, effective);
+                            this.doubleBuffered = effective.doubleBuffer;
+                        } finally {
+                            invokePPV(pixelFormat, sel_getUid("release"), objc_msgSend);
                         }
-                        configureSwapInterval(context, attribs.swapInterval);
-                        populateEffectiveData(context, effective);
-                        this.context = context;
-                        this.doubleBuffered = effective.doubleBuffer;
                     } finally {
-                        invokePPV(pixelFormat, sel_getUid("release"), objc_msgSend);
+                        JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
                     }
                 } finally {
-                    JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
+                    JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
                 }
             } finally {
-                JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
+                JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
             }
-        } finally {
-            JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
-        }
 
-        attachSurfaceLayer(surfaceLayer, interLayer);
-        performSelectorOnMainThread(interLayer, sel_getUid("release"), MemoryUtil.NULL);
-        return context;
+            attachSurfaceLayer(surfaceLayer, interLayer);
+            performSelectorOnMainThread(interLayer, sel_getUid("release"), MemoryUtil.NULL);
+            return context;
+        } catch (AWTException | RuntimeException | Error failure) {
+            try {
+                releaseFailedCreation();
+            } catch (RuntimeException | Error cleanupFailure) {
+                failure.addSuppressed(cleanupFailure);
+            }
+            throw failure;
+        }
     }
 
     /**
@@ -147,12 +175,12 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     }
 
     private static long createPixelFormat(int[] attributes) {
-        IntBuffer attributeBuffer = BufferUtils.createIntBuffer(attributes.length);
-        attributeBuffer.put(attributes);
-        attributeBuffer.flip();
-        long pixelFormat = invokePPP(NSOpenGLPixelFormat, sel_getUid("alloc"), objc_msgSend);
-        return invokePPPP(pixelFormat, sel_getUid("initWithAttributes:"),
-                MemoryUtil.memAddress(attributeBuffer), objc_msgSend);
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer attributeBuffer = stack.ints(attributes);
+            long pixelFormat = invokePPP(NSOpenGLPixelFormat, sel_getUid("alloc"), objc_msgSend);
+            return invokePPPP(pixelFormat, sel_getUid("initWithAttributes:"),
+                    MemoryUtil.memAddress(attributeBuffer), objc_msgSend);
+        }
     }
 
     private static void configureSwapInterval(long context, Integer swapInterval) throws AWTException {
@@ -190,23 +218,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         effective.accumBlueSize = accumSize / 4 + (accumSize % 4 > 2 ? 1 : 0);
         effective.accumAlphaSize = accumSize / 4;
 
-        int profile = describePixelFormat(pixelFormat, kCGLPFAOpenGLProfile);
         effective.api = GLData.API.GL;
-        if (profile == MacOSXGLDataUtil.NS_OPENGL_PROFILE_4_1_CORE) {
-            effective.majorVersion = 4;
-            effective.minorVersion = 1;
-            effective.profile = GLData.Profile.CORE;
-        } else if (profile == MacOSXGLDataUtil.NS_OPENGL_PROFILE_3_2_CORE) {
-            effective.majorVersion = 3;
-            effective.minorVersion = 2;
-            effective.profile = GLData.Profile.CORE;
-        } else {
-            effective.majorVersion = 2;
-            effective.minorVersion = 1;
-            effective.profile = null;
-        }
-        effective.forwardCompatible = effective.profile == GLData.Profile.CORE;
-        effective.debug = false;
         effective.sRGB = false;
         effective.contextReleaseBehavior = null;
         effective.colorSamplesNV = 0;
@@ -222,6 +234,83 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
             throw cglException("Failed to query the effective swap interval", error);
         }
         effective.swapInterval = swapInterval[0];
+        populateEffectiveContextData(context, effective);
+    }
+
+    private static void populateEffectiveContextData(long context, GLData effective) throws AWTException {
+        long previousContext = CGLGetCurrentContext();
+        int error = CGLSetCurrentContext(context);
+        if (error != kCGLNoError) {
+            throw cglException("Failed to make the new context current while querying it", error);
+        }
+        try {
+            queryEffectiveContextData(effective);
+        } catch (AWTException | RuntimeException | Error failure) {
+            int restoreError = CGLSetCurrentContext(previousContext);
+            if (restoreError != kCGLNoError) {
+                failure.addSuppressed(cglException("Failed to restore the previous OpenGL context", restoreError));
+            }
+            throw failure;
+        }
+        error = CGLSetCurrentContext(previousContext);
+        if (error != kCGLNoError) {
+            throw cglException("Failed to restore the previous OpenGL context", error);
+        }
+    }
+
+    private static void queryEffectiveContextData(GLData effective) throws AWTException {
+        long glGetString = GL.getFunctionProvider().getFunctionAddress("glGetString");
+        long glGetIntegerv = GL.getFunctionProvider().getFunctionAddress("glGetIntegerv");
+        if (glGetString == 0L || glGetIntegerv == 0L) {
+            throw new AWTException("Failed to resolve OpenGL context-query functions");
+        }
+
+        APIVersion version = APIUtil.apiParseVersion(getString(GL11.GL_VERSION, glGetString));
+        effective.majorVersion = version.major;
+        effective.minorVersion = version.minor;
+        effective.profile = null;
+        effective.debug = false;
+        effective.forwardCompatible = false;
+        effective.robustness = false;
+        effective.loseContextOnReset = false;
+        effective.contextResetIsolation = false;
+
+        if (GLUtil.atLeast32(version.major, version.minor)) {
+            int profileMask = getInteger(GL32.GL_CONTEXT_PROFILE_MASK, glGetIntegerv);
+            if ((profileMask & GL32.GL_CONTEXT_CORE_PROFILE_BIT) != 0) {
+                effective.profile = GLData.Profile.CORE;
+            } else if ((profileMask & GL32.GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) != 0) {
+                effective.profile = GLData.Profile.COMPATIBILITY;
+            } else if (profileMask != 0) {
+                throw new AWTException("Unknown OpenGL context profile mask: " + profileMask);
+            }
+        }
+        if (GLUtil.atLeast30(version.major, version.minor)) {
+            int contextFlags = getInteger(GL30.GL_CONTEXT_FLAGS, glGetIntegerv);
+            effective.debug = (contextFlags & GL43.GL_CONTEXT_FLAG_DEBUG_BIT) != 0;
+            effective.forwardCompatible =
+                    (contextFlags & GL30.GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT) != 0;
+            effective.robustness =
+                    (contextFlags & ARBRobustness.GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB) != 0;
+            if (effective.robustness) {
+                int resetStrategy =
+                        getInteger(ARBRobustness.GL_RESET_NOTIFICATION_STRATEGY_ARB, glGetIntegerv);
+                effective.loseContextOnReset =
+                        resetStrategy == ARBRobustness.GL_LOSE_CONTEXT_ON_RESET_ARB;
+            }
+        }
+    }
+
+    private static int getInteger(int pname, long function) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer value = stack.callocInt(1);
+            JNI.callPV(pname, memAddress(value), function);
+            return value.get(0);
+        }
+    }
+
+    private static String getString(int pname, long function) {
+        return MemoryUtil.memUTF8(Checks.check(JNI.callP(pname, function)));
     }
 
     private static int describePixelFormat(long pixelFormat, int attribute) throws AWTException {
@@ -249,6 +338,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         // init NSOpenGLView with frame and device
         // NSOpenGLView *view = [nsOpenGLView initWithFrame:pixelFormat:];
         long view = NSOpenGLView_initWithFrame(nsOpenGLView, 0, 0, width, height, pixelFormat);
+        this.view = view;
 
         // make NSOpenGLView layer-backed
         // [view setWantsLayer:YES];
@@ -262,6 +352,9 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         long openglViewLayer = JNI.invokePPJ(view,
                 ObjCRuntime.sel_getUid("layer"),
                 objc_msgSend);
+        if (openglViewLayer == 0L) {
+            throw new IllegalStateException("NSOpenGLView returned no Core Animation layer");
+        }
 
         // The layer must not autoresize with the intermediate layer. Core Animation's autoresizing applies the
         // superlayer's bounds *delta* to its sublayers, and the intermediate layer's frame is applied
@@ -277,11 +370,15 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
         // create intermediate layer and set its frame
         // CALayer *interLayer = [CALayer layer];
-		interLayer = JNI.invokePPP(
+        long intermediateLayer = JNI.invokePPP(
                 ObjCRuntime.objc_getClass("CALayer"),
                 ObjCRuntime.sel_getUid("layer"),
                 objc_msgSend);
-        invokePPP(interLayer, sel_getUid("retain"), objc_msgSend);
+        if (intermediateLayer == 0L) {
+            throw new IllegalStateException("Unable to create the intermediate Core Animation layer");
+        }
+        invokePPP(intermediateLayer, sel_getUid("retain"), objc_msgSend);
+        interLayer = intermediateLayer;
 
         // [interLayer setFrame:CGRectMake(x, y, width, height)];
         setFrameOnMainThread(interLayer, x, y, width, height);
@@ -408,6 +505,76 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         elements.put(MemoryUtil.NULL);
         elements.flip();
         return FFIType.calloc(stack).type(FFI_TYPE_STRUCT).elements(elements);
+    }
+
+    private void releaseFailedCreation() {
+        long failedContext = this.context;
+        long failedView = this.view;
+        long failedInterLayer = this.interLayer;
+        long failedSurfaceLayer = this.surfaceLayer;
+        this.context = 0L;
+        this.view = 0L;
+        this.interLayer = 0L;
+        this.surfaceLayer = 0L;
+        this.doubleBuffered = false;
+        this.canvas = null;
+
+        Throwable cleanupFailure = null;
+        if (failedContext != 0L && CGLGetCurrentContext() == failedContext) {
+            int clearContextError = CGLSetCurrentContext(0L);
+            if (clearContextError != kCGLNoError) {
+                cleanupFailure = new IllegalStateException("Failed to clear the partially created OpenGL context: "
+                        + CGLErrorString(clearContextError) + " (" + clearContextError + ")");
+            }
+        }
+
+        // These selectors share AppKit's FIFO queue with layer creation, so teardown remains ordered even when
+        // creation fails after some native objects have already been initialized.
+        if (failedSurfaceLayer != 0L) {
+            cleanupFailure = runCleanup(cleanupFailure,
+                    () -> performSelectorOnMainThread(
+                            failedSurfaceLayer, sel_getUid("setLayer:"), MemoryUtil.NULL));
+        }
+        if (failedView != 0L) {
+            cleanupFailure = runCleanup(cleanupFailure,
+                    () -> performSelectorOnMainThread(failedView,
+                            sel_getUid("removeFromSuperviewWithoutNeedingDisplay"), MemoryUtil.NULL));
+            cleanupFailure = runCleanup(cleanupFailure,
+                    () -> performSelectorOnMainThread(
+                            failedView, sel_getUid("clearGLContext"), MemoryUtil.NULL));
+            cleanupFailure = runCleanup(cleanupFailure,
+                    () -> performSelectorOnMainThread(failedView, sel_getUid("release"), MemoryUtil.NULL));
+        }
+        if (failedSurfaceLayer != 0L) {
+            cleanupFailure = runCleanup(cleanupFailure,
+                    () -> performSelectorOnMainThread(
+                            failedSurfaceLayer, sel_getUid("release"), MemoryUtil.NULL));
+        }
+        if (failedInterLayer != 0L) {
+            cleanupFailure = runCleanup(cleanupFailure,
+                    () -> performSelectorOnMainThread(
+                            failedInterLayer, sel_getUid("release"), MemoryUtil.NULL));
+        }
+        if (cleanupFailure instanceof Error) {
+            throw (Error) cleanupFailure;
+        }
+        if (cleanupFailure != null) {
+            throw (RuntimeException) cleanupFailure;
+        }
+    }
+
+    private static Throwable runCleanup(Throwable previousFailure, Runnable cleanup) {
+        try {
+            cleanup.run();
+        } catch (RuntimeException | Error failure) {
+            if (previousFailure == null) {
+                return failure;
+            }
+            if (previousFailure != failure) {
+                previousFailure.addSuppressed(failure);
+            }
+        }
+        return previousFailure;
     }
 
     @Override

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -17,6 +17,7 @@ import java.awt.event.HierarchyEvent;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
+import java.nio.IntBuffer;
 
 import static org.lwjgl.opengl.CGL.*;
 import static org.lwjgl.opengl.GL11.glFlush;
@@ -29,51 +30,6 @@ import static org.lwjgl.system.macosx.ObjCRuntime.objc_getClass;
 import static org.lwjgl.system.macosx.ObjCRuntime.sel_getUid;
 
 public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
-    private static final int NSOpenGLPFAAllRenderers = 1;    /* choose from all available renderers          */
-    private static final int NSOpenGLPFATripleBuffer = 3;    /* choose a triple buffered pixel format        */
-    private static final int NSOpenGLPFADoubleBuffer = 5;    /* choose a double buffered pixel format        */
-    private static final int NSOpenGLPFAAuxBuffers = 7;    /* number of aux buffers                        */
-    private static final int NSOpenGLPFAColorSize = 8;    /* number of color buffer bits                  */
-    private static final int NSOpenGLPFAAlphaSize = 11;    /* number of alpha component bits               */
-    private static final int NSOpenGLPFADepthSize = 12;    /* number of depth buffer bits                  */
-    private static final int NSOpenGLPFAStencilSize = 13;    /* number of stencil buffer bits                */
-    private static final int NSOpenGLPFAAccumSize = 14;    /* number of accum buffer bits                  */
-    private static final int NSOpenGLPFAMinimumPolicy = 51;    /* never choose smaller buffers than requested  */
-    private static final int NSOpenGLPFAMaximumPolicy = 52;    /* choose largest buffers of type requested     */
-    private static final int NSOpenGLPFASampleBuffers = 55;    /* number of multi sample buffers               */
-    private static final int NSOpenGLPFASamples = 56;    /* number of samples per multi sample buffer    */
-    private static final int NSOpenGLPFAAuxDepthStencil = 57;    /* each aux buffer has its own depth stencil    */
-    private static final int NSOpenGLPFAColorFloat = 58;    /* color buffers store floating point pixels    */
-    private static final int NSOpenGLPFAMultisample = 59;    /* choose multisampling                         */
-    private static final int NSOpenGLPFASupersample = 60;    /* choose supersampling                         */
-    private static final int NSOpenGLPFASampleAlpha = 61;    /* request alpha filtering                      */
-    private static final int NSOpenGLPFARendererID = 70;    /* request renderer by ID                       */
-    private static final int NSOpenGLPFANoRecovery = 72;    /* disable all failure recovery systems         */
-    private static final int NSOpenGLPFAAccelerated = 73;    /* choose a hardware accelerated renderer       */
-    private static final int NSOpenGLPFAClosestPolicy = 74;    /* choose the closest color buffer to request   */
-    private static final int NSOpenGLPFABackingStore = 76;    /* back buffer contents are valid after swap    */
-    private static final int NSOpenGLPFAScreenMask = 84;    /* bit mask of supported physical screens       */
-    private static final int NSOpenGLPFAAllowOfflineRenderers = 96;  /* allow use of offline renderers               */
-    private static final int NSOpenGLPFAAcceleratedCompute = 97;    /* choose a hardware accelerated compute device */
-    private static final int NSOpenGLPFAOpenGLProfile = 99;    /* specify an OpenGL Profile to use             */
-    private static final int NSOpenGLPFAVirtualScreenCount = 128;    /* number of virtual screens in this format     */
-
-    private static final int NSOpenGLPFAStereo = 6;
-    private static final int NSOpenGLPFAOffScreen = 53;
-    private static final int NSOpenGLPFAFullScreen = 54;
-    private static final int NSOpenGLPFASingleRenderer = 71;
-    private static final int NSOpenGLPFARobust = 75;
-    private static final int NSOpenGLPFAMPSafe = 78;
-    private static final int NSOpenGLPFAWindow = 80;
-    private static final int NSOpenGLPFAMultiScreen = 81;
-    private static final int NSOpenGLPFACompliant = 83;
-    private static final int NSOpenGLPFAPixelBuffer = 90;
-    private static final int NSOpenGLPFARemotePixelBuffer = 91;
-
-    private static final int NSOpenGLProfileVersion3_2Core = 0x3200;
-    private static final int NSOpenGLProfileVersionLegacy = 0x1000;
-    private static final int NSOpenGLProfileVersion4_1Core = 0x4100;
-
     public static final JAWT awt;
     private static final long objc_msgSend;
     private static final long objc_autoreleasePoolPush;
@@ -104,9 +60,15 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     private int layerY;
     private int layerWidth;
     private int layerHeight;
+    private long context;
+    private boolean doubleBuffered;
 
     @Override
     public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
+        GLUtil.validateAttributes(attribs);
+        if (attribs.api != GLData.API.GL) {
+            throw new AWTException("macOS NSOpenGL does not support OpenGL ES contexts");
+        }
         this.canvas = canvas;
         if (!hierarchyListenerAdded) {
             canvas.addHierarchyListener(e -> {
@@ -138,90 +100,27 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                     this.layerWidth = layerBounds[2];
                     this.layerHeight = layerBounds[3];
 
-                    //TODO: we don't really need 100
-                    ByteBuffer attribsArray = ByteBuffer.allocateDirect(4 * 100).order(ByteOrder.nativeOrder());
-                    attribsArray.putInt(NSOpenGLPFAAccelerated);
-                    attribsArray.putInt(NSOpenGLPFAClosestPolicy);
-                    if (attribs.stereo) {
-                        attribsArray.putInt(NSOpenGLPFAStereo);
-                    }
-                    if (attribs.doubleBuffer) {
-                        //doesn't work currently
-                        //attribsArray.putInt(NSOpenGLPFADoubleBuffer);
-                    }
-
-                    if (attribs.pixelFormatFloat) {
-                        attribsArray.putInt(NSOpenGLPFAColorFloat);
-                    }
-
-                    attribsArray.putInt(NSOpenGLPFAAccumSize);
-                    attribsArray.putInt(attribs.accumRedSize + attribs.accumGreenSize + attribs.accumBlueSize + attribs.accumAlphaSize);
-
-                    int colorBits = attribs.redSize +
-                            attribs.greenSize +
-                            attribs.blueSize;
-
-                    // macOS needs non-zero color size, so set reasonable values
-                    if (colorBits == 0)
-                        colorBits = 24;
-                    else if (colorBits < 15)
-                        colorBits = 15;
-
-                    attribsArray.putInt(NSOpenGLPFAColorSize);
-                    attribsArray.putInt(colorBits);
-
-                    attribsArray.putInt(NSOpenGLPFAAlphaSize);
-                    attribsArray.putInt(attribs.alphaSize);
-
-                    attribsArray.putInt(NSOpenGLPFADepthSize);
-                    attribsArray.putInt(attribs.depthSize);
-
-                    attribsArray.putInt(NSOpenGLPFAStencilSize);
-                    attribsArray.putInt(attribs.stencilSize);
-
-                    if (attribs.samples == 0) {
-                        attribsArray.putInt(NSOpenGLPFASampleBuffers);
-                        attribsArray.putInt(0);
-                    } else {
-                        attribsArray.putInt(NSOpenGLPFASampleBuffers);
-                        attribsArray.putInt(1);
-                        attribsArray.putInt(NSOpenGLPFASamples);
-                        attribsArray.putInt(attribs.samples);
-                    }
-
-                    if (attribs.profile == GLData.Profile.CORE) {
-                        attribsArray.putInt(NSOpenGLPFAOpenGLProfile);
-                        attribsArray.putInt(NSOpenGLProfileVersion3_2Core);
-                    }
-                    if (attribs.profile == GLData.Profile.COMPATIBILITY) {
-                        attribsArray.putInt(NSOpenGLPFAOpenGLProfile);
-                        attribsArray.putInt(NSOpenGLProfileVersionLegacy);
-                    } else {
-                        if (attribs.majorVersion >= 4) {
-                            attribsArray.putInt(NSOpenGLPFAOpenGLProfile);
-                            attribsArray.putInt(NSOpenGLProfileVersion4_1Core);
-                        } else if (attribs.majorVersion >= 3) {
-                            attribsArray.putInt(NSOpenGLPFAOpenGLProfile);
-                            attribsArray.putInt(NSOpenGLProfileVersion3_2Core);
-                        } else {
-                            attribsArray.putInt(NSOpenGLPFAOpenGLProfile);
-                            attribsArray.putInt(NSOpenGLProfileVersionLegacy);
+                    MacOSXGLDataUtil.PixelFormatSelection selection =
+                            MacOSXGLDataUtil.choosePixelFormat(attribs, PlatformMacOSXGLCanvas::createPixelFormat);
+                    long pixelFormat = selection.pixelFormat;
+                    try {
+                        view = createNSOpenGLView(pixelFormat,
+                                layerBounds[0], layerBounds[1], layerBounds[2], layerBounds[3]);
+                        // The surface layer belongs to the peer view rather than to the drawing surface info, but
+                        // retain it so it stays alive until the context is deleted.
+                        surfaceLayer = invokePPP(dsi.platformInfo(), sel_getUid("retain"), objc_msgSend);
+                        long openGLContext = invokePPP(view, sel_getUid("openGLContext"), objc_msgSend);
+                        context = invokePPP(openGLContext, sel_getUid("CGLContextObj"), objc_msgSend);
+                        if (context == 0L) {
+                            throw new AWTException("NSOpenGLView returned no OpenGL context");
                         }
+                        configureSwapInterval(context, attribs.swapInterval);
+                        populateEffectiveData(context, effective);
+                        this.context = context;
+                        this.doubleBuffered = effective.doubleBuffer;
+                    } finally {
+                        invokePPV(pixelFormat, sel_getUid("release"), objc_msgSend);
                     }
-
-                    // 0 Terminated
-                    attribsArray.putInt(0).rewind();
-
-                    long pixelFormat = invokePPP(NSOpenGLPixelFormat, sel_getUid("alloc"), objc_msgSend);
-                    pixelFormat = invokePPPP(pixelFormat, sel_getUid("initWithAttributes:"), MemoryUtil.memAddress(attribsArray), objc_msgSend);
-
-                    view = createNSOpenGLView(pixelFormat,
-                            layerBounds[0], layerBounds[1], layerBounds[2], layerBounds[3]);
-                    // The surface layer belongs to the peer view rather than to the drawing surface info, but
-                    // retain it so it stays alive until the context is deleted.
-                    surfaceLayer = invokePPP(dsi.platformInfo(), sel_getUid("retain"), objc_msgSend);
-                    long openGLContext = invokePPP(view, sel_getUid("openGLContext"), objc_msgSend);
-                    context = invokePPP(openGLContext, sel_getUid("CGLContextObj"), objc_msgSend);
                 } finally {
                     JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, ds.FreeDrawingSurfaceInfo());
                 }
@@ -245,6 +144,97 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
      */
     private static void attachSurfaceLayer(long surfaceLayer, long layer) {
         performSelectorOnMainThread(surfaceLayer, sel_getUid("setLayer:"), layer);
+    }
+
+    private static long createPixelFormat(int[] attributes) {
+        IntBuffer attributeBuffer = BufferUtils.createIntBuffer(attributes.length);
+        attributeBuffer.put(attributes);
+        attributeBuffer.flip();
+        long pixelFormat = invokePPP(NSOpenGLPixelFormat, sel_getUid("alloc"), objc_msgSend);
+        return invokePPPP(pixelFormat, sel_getUid("initWithAttributes:"),
+                MemoryUtil.memAddress(attributeBuffer), objc_msgSend);
+    }
+
+    private static void configureSwapInterval(long context, Integer swapInterval) throws AWTException {
+        if (swapInterval == null) {
+            return;
+        }
+        int error = CGLSetParameter(context, kCGLCPSwapInterval, swapInterval);
+        if (error != kCGLNoError) {
+            throw cglException("Failed to set the swap interval", error);
+        }
+    }
+
+    private static void populateEffectiveData(long context, GLData effective) throws AWTException {
+        long pixelFormat = CGLGetPixelFormat(context);
+        if (pixelFormat == 0L) {
+            throw new AWTException("CGL returned no pixel format for the new context");
+        }
+
+        effective.alphaSize = describePixelFormat(pixelFormat, kCGLPFAAlphaSize);
+        int colorSize = Math.max(0, describePixelFormat(pixelFormat, kCGLPFAColorSize) - effective.alphaSize);
+        effective.redSize = colorSize / 3 + (colorSize % 3 > 0 ? 1 : 0);
+        effective.greenSize = colorSize / 3 + (colorSize % 3 > 1 ? 1 : 0);
+        effective.blueSize = colorSize / 3;
+        effective.depthSize = describePixelFormat(pixelFormat, kCGLPFADepthSize);
+        effective.stencilSize = describePixelFormat(pixelFormat, kCGLPFAStencilSize);
+        effective.doubleBuffer = describePixelFormat(pixelFormat, kCGLPFADoubleBuffer) != 0;
+        effective.stereo = describePixelFormat(pixelFormat, kCGLPFAStereo) != 0;
+        effective.pixelFormatFloat = describePixelFormat(pixelFormat, kCGLPFAColorFloat) != 0;
+        effective.sampleBuffers = describePixelFormat(pixelFormat, kCGLPFASampleBuffers);
+        effective.samples = describePixelFormat(pixelFormat, kCGLPFASamples);
+
+        int accumSize = describePixelFormat(pixelFormat, kCGLPFAAccumSize);
+        effective.accumRedSize = accumSize / 4 + (accumSize % 4 > 0 ? 1 : 0);
+        effective.accumGreenSize = accumSize / 4 + (accumSize % 4 > 1 ? 1 : 0);
+        effective.accumBlueSize = accumSize / 4 + (accumSize % 4 > 2 ? 1 : 0);
+        effective.accumAlphaSize = accumSize / 4;
+
+        int profile = describePixelFormat(pixelFormat, kCGLPFAOpenGLProfile);
+        effective.api = GLData.API.GL;
+        if (profile == MacOSXGLDataUtil.NS_OPENGL_PROFILE_4_1_CORE) {
+            effective.majorVersion = 4;
+            effective.minorVersion = 1;
+            effective.profile = GLData.Profile.CORE;
+        } else if (profile == MacOSXGLDataUtil.NS_OPENGL_PROFILE_3_2_CORE) {
+            effective.majorVersion = 3;
+            effective.minorVersion = 2;
+            effective.profile = GLData.Profile.CORE;
+        } else {
+            effective.majorVersion = 2;
+            effective.minorVersion = 1;
+            effective.profile = null;
+        }
+        effective.forwardCompatible = effective.profile == GLData.Profile.CORE;
+        effective.debug = false;
+        effective.sRGB = false;
+        effective.contextReleaseBehavior = null;
+        effective.colorSamplesNV = 0;
+        effective.swapGroupNV = 0;
+        effective.swapBarrierNV = 0;
+        effective.robustness = false;
+        effective.loseContextOnReset = false;
+        effective.contextResetIsolation = false;
+
+        int[] swapInterval = new int[1];
+        int error = CGLGetParameter(context, kCGLCPSwapInterval, swapInterval);
+        if (error != kCGLNoError) {
+            throw cglException("Failed to query the effective swap interval", error);
+        }
+        effective.swapInterval = swapInterval[0];
+    }
+
+    private static int describePixelFormat(long pixelFormat, int attribute) throws AWTException {
+        int[] value = new int[1];
+        int error = CGLDescribePixelFormat(pixelFormat, 0, attribute, value);
+        if (error != kCGLNoError) {
+            throw cglException("Failed to query macOS pixel format attribute " + attribute, error);
+        }
+        return value[0];
+    }
+
+    private static AWTException cglException(String message, int error) {
+        return new AWTException(message + ": " + CGLErrorString(error) + " (" + error + ")");
     }
 
     private long createNSOpenGLView(long pixelFormat, int x, int y, int width, int height) {
@@ -422,8 +412,12 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     @Override
     public boolean swapBuffers() {
-        glFlush();
-        return true;
+        if (!doubleBuffered) {
+            glFlush();
+            return true;
+        }
+        long currentContext = CGLGetCurrentContext();
+        return currentContext == context && CGLFlushDrawable(context) == kCGLNoError;
     }
 
     @Override
@@ -433,6 +427,8 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         this.view = 0L;
         this.interLayer = 0L;
         this.surfaceLayer = 0L;
+        this.context = 0L;
+        this.doubleBuffered = false;
 
         // Keep teardown ordered behind any pending layer updates and run it on AppKit's main thread. Clearing an
         // NSOpenGLContext concurrently with Core Animation displaying its backing layer can abort inside setView:.

--- a/test/org/lwjgl/opengl/awt/CompareScreenshotTest.java
+++ b/test/org/lwjgl/opengl/awt/CompareScreenshotTest.java
@@ -34,8 +34,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.lwjgl.system.Platform;
 
 import static org.lwjgl.opengl.GL.createCapabilities;
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
@@ -157,7 +156,7 @@ public class CompareScreenshotTest {
     }
 
     @Test
-    @EnabledOnOs({OS.LINUX, OS.WINDOWS})
+    @EnabledForRobotScreenCapture
     void robotCapturesCanvasInContentPane(TestInfo testInfo)
             throws IOException, InvocationTargetException, InterruptedException {
         DemoCanvas canvas = showSingleCanvas();
@@ -165,7 +164,7 @@ public class CompareScreenshotTest {
     }
 
     @Test
-    @EnabledOnOs({OS.LINUX, OS.WINDOWS})
+    @EnabledForRobotScreenCapture
     void robotCapturesCanvasInSplitPane(TestInfo testInfo)
             throws IOException, InvocationTargetException, InterruptedException {
         DemoCanvas[] canvases = showSplitCanvases();
@@ -173,7 +172,7 @@ public class CompareScreenshotTest {
     }
 
     @Test
-    @EnabledOnOs({OS.LINUX, OS.WINDOWS})
+    @EnabledForRobotScreenCapture
     void robotCapturesReAddedCanvas(TestInfo testInfo)
             throws IOException, InvocationTargetException, InterruptedException {
         DemoCanvas canvas = showSingleCanvas();
@@ -189,7 +188,7 @@ public class CompareScreenshotTest {
     }
 
     @Test
-    @EnabledOnOs({OS.LINUX, OS.WINDOWS})
+    @EnabledForRobotScreenCapture
     void robotCapturesHiddenAndShownCanvas(TestInfo testInfo)
             throws IOException, InvocationTargetException, InterruptedException {
         DemoCanvas canvas = showSingleCanvas();
@@ -275,7 +274,7 @@ public class CompareScreenshotTest {
 
     private void compareWithScreenshot(TestInfo testInfo, JFrame frame, AWTGLCanvas... canvases) throws IOException {
         String expectedMethodName = testInfo.getTestMethod().map(Method::getName).orElse("unknown");
-        compareWithExpectedScreenshot(testInfo, expectedMethodName, captureContentPane(frame, canvases));
+        compareWithExpectedScreenshot(testInfo, expectedMethodName, captureContentPane(frame, canvases), false);
     }
 
     private void compareDisplayedWithScreenshot(
@@ -286,13 +285,15 @@ public class CompareScreenshotTest {
         compareWithExpectedScreenshot(
                 testInfo,
                 expectedMethodName,
-                captureDisplayedContentPane(frame, canvases));
+                captureDisplayedContentPane(frame, canvases),
+                true);
     }
 
     private void compareWithExpectedScreenshot(
             TestInfo testInfo,
             String expectedMethodName,
-            BufferedImage background) throws IOException {
+            BufferedImage background,
+            boolean capturedFromDisplay) throws IOException {
         String actualMethodName = testInfo.getTestMethod().map(Method::getName).orElse("unknown");
 
         String screenShotSuffix = "";
@@ -319,8 +320,16 @@ public class CompareScreenshotTest {
 
         //Create ImageComparison object for it.
         ImageComparison imageComparison = new ImageComparison(expectedImage, background, resultDestination);
-        // Ignore a small number of platform-dependent pixels at component boundaries.
-        imageComparison.setAllowingPercentOfDifferentPixels(0.02d);
+        if (capturedFromDisplay && Platform.get() == Platform.MACOSX) {
+            // Robot observes color-managed and Retina-rasterized pixels, as well as the rounded pixels at the
+            // bottom of a macOS window. Keep the permitted area small enough that misplaced or missing canvas
+            // content still fails while tolerating those compositor-only differences.
+            imageComparison.setPixelToleranceLevel(0.20d);
+            imageComparison.setAllowingPercentOfDifferentPixels(0.10d);
+        } else {
+            // Ignore a small number of platform-dependent pixels at component boundaries.
+            imageComparison.setAllowingPercentOfDifferentPixels(0.02d);
+        }
         Assertions.assertEquals(
                 ImageComparisonState.MATCH,
                 imageComparison.compareImages().getImageComparisonState());
@@ -329,18 +338,21 @@ public class CompareScreenshotTest {
     /**
      * Captures the pixels presented by the window system. This retains end-to-end
      * coverage of native canvas placement, visibility and buffer presentation on
-     * platforms where Robot screen capture does not require user permission.
+     * platforms where Robot screen capture is enabled by {@link EnabledForRobotScreenCapture}.
      */
     private BufferedImage captureDisplayedContentPane(JFrame frame, AWTGLCanvas... canvases) throws IOException {
         final Rectangle[] captureBounds = new Rectangle[1];
         try {
             SwingUtilities.invokeAndWait(() -> {
+                if (frame.isAlwaysOnTopSupported()) {
+                    frame.setAlwaysOnTop(true);
+                }
                 frame.toFront();
+                frame.requestFocus();
                 for (AWTGLCanvas canvas : canvases) {
                     if (!canvas.isValid()) {
                         throw new IllegalStateException("Cannot capture an invalid OpenGL canvas");
                     }
-                    canvas.render();
                 }
 
                 Container contentPane = frame.getContentPane();
@@ -355,12 +367,24 @@ public class CompareScreenshotTest {
             Robot robot = new Robot();
             robot.waitForIdle();
             robot.delay(100);
-            BufferedImage previous = robot.createScreenCapture(captureBounds[0]);
+            BufferedImage previous = null;
             long deadline = System.currentTimeMillis() + SCREEN_STABILITY_TIMEOUT_MILLIS;
             while (System.currentTimeMillis() < deadline) {
+                // macOS applies native layer bounds asynchronously on AppKit's main thread. Rendering each pass
+                // prevents a stable but blank first capture from winning before those bounds have taken effect.
+                SwingUtilities.invokeAndWait(() -> {
+                    for (AWTGLCanvas canvas : canvases) {
+                        if (!canvas.isValid()) {
+                            throw new IllegalStateException("Cannot capture an invalid OpenGL canvas");
+                        }
+                        canvas.render();
+                    }
+                });
+                robot.waitForIdle();
                 robot.delay(50);
                 BufferedImage current = robot.createScreenCapture(captureBounds[0]);
-                if (new ImageComparison(previous, current).compareImages().getDifferencePercent() == 0.0f) {
+                if (previous != null
+                        && new ImageComparison(previous, current).compareImages().getDifferencePercent() == 0.0f) {
                     return current;
                 }
                 previous = current;

--- a/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
+import org.lwjgl.opengl.ARBRobustness;
 import org.lwjgl.opengl.GL;
+import org.lwjgl.system.APIUtil;
+import org.lwjgl.system.APIUtil.APIVersion;
 import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
@@ -19,10 +22,13 @@ import javax.swing.JPanel;
 import javax.swing.JRootPane;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
+import java.awt.AWTException;
 import java.awt.Canvas;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.IllegalComponentStateException;
 import java.awt.Point;
+import java.awt.Robot;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 
@@ -30,6 +36,7 @@ import static java.nio.ByteOrder.nativeOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.lwjgl.system.MemoryUtil.memAddress;
@@ -54,12 +61,20 @@ import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_FRONT;
 import static org.lwjgl.opengl.GL11.GL_RGBA;
 import static org.lwjgl.opengl.GL11.GL_UNSIGNED_BYTE;
+import static org.lwjgl.opengl.GL11.GL_VERSION;
 import static org.lwjgl.opengl.GL11.glClear;
 import static org.lwjgl.opengl.GL11.glClearColor;
 import static org.lwjgl.opengl.GL11.glDrawBuffer;
 import static org.lwjgl.opengl.GL11.glFinish;
+import static org.lwjgl.opengl.GL11.glGetInteger;
+import static org.lwjgl.opengl.GL11.glGetString;
 import static org.lwjgl.opengl.GL11.glReadBuffer;
 import static org.lwjgl.opengl.GL11.glReadPixels;
+import static org.lwjgl.opengl.GL30.GL_CONTEXT_FLAGS;
+import static org.lwjgl.opengl.GL30.GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT;
+import static org.lwjgl.opengl.GL32.GL_CONTEXT_CORE_PROFILE_BIT;
+import static org.lwjgl.opengl.GL32.GL_CONTEXT_PROFILE_MASK;
+import static org.lwjgl.opengl.GL43.GL_CONTEXT_FLAG_DEBUG_BIT;
 
 @EnabledOnOs(OS.MAC)
 class MacOSXGLCanvasLifecycleTest {
@@ -85,6 +100,17 @@ class MacOSXGLCanvasLifecycleTest {
         assertEquals(155, bounds[1]);
         assertEquals(160, bounds[2]);
         assertEquals(120, bounds[3]);
+    }
+
+    @Test
+    void rejectsContextSharingInsteadOfSilentlyIgnoringIt() {
+        GLData data = new GLData();
+        data.shareContext = new TestCanvas();
+
+        AWTException failure = assertThrows(AWTException.class,
+                () -> MacOSXGLDataUtil.validateAttributes(data));
+
+        assertTrue(failure.getMessage().contains("sharing"));
     }
 
     @Test
@@ -163,7 +189,16 @@ class MacOSXGLCanvasLifecycleTest {
             assertEquals(Integer.valueOf(0), canvas.effective.swapInterval);
             assertEquals(GLData.API.GL, canvas.effective.api);
             assertEquals(GLData.Profile.CORE, canvas.effective.profile);
-            assertTrue(canvas.effective.majorVersion >= 3);
+            assertEquals(canvas.actualMajorVersion, canvas.effective.majorVersion);
+            assertEquals(canvas.actualMinorVersion, canvas.effective.minorVersion);
+            assertEquals((canvas.actualProfileMask & GL_CONTEXT_CORE_PROFILE_BIT) != 0,
+                    canvas.effective.profile == GLData.Profile.CORE);
+            assertEquals((canvas.actualContextFlags & GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT) != 0,
+                    canvas.effective.forwardCompatible);
+            assertEquals((canvas.actualContextFlags & GL_CONTEXT_FLAG_DEBUG_BIT) != 0,
+                    canvas.effective.debug);
+            assertEquals((canvas.actualContextFlags & ARBRobustness.GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB) != 0,
+                    canvas.effective.robustness);
             assertEquals(8, canvas.effective.redSize);
             assertEquals(8, canvas.effective.greenSize);
             assertEquals(8, canvas.effective.blueSize);
@@ -200,6 +235,21 @@ class MacOSXGLCanvasLifecycleTest {
             assertPresentedFrameEventually(state);
             TestCanvas canvas = state.canvases[0];
             assertTrue(canvas.effective.doubleBuffer);
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
+
+    @Test
+    void presentsDoubleBufferedFrameThroughWindowCompositor() throws Exception {
+        GLData data = new GLData();
+        data.doubleBuffer = true;
+        data.swapInterval = 0;
+
+        FrameState state = showPresentingCanvas(data);
+        try {
+            assertPresentedFrameEventually(state);
+            assertCompositedFrameEventually(state);
         } finally {
             SwingUtilities.invokeAndWait(state.frame::dispose);
         }
@@ -398,6 +448,41 @@ class MacOSXGLCanvasLifecycleTest {
         return Math.abs(expected - actual) <= 1;
     }
 
+    private static void assertCompositedFrameEventually(FrameState state) throws Exception {
+        TestCanvas canvas = state.canvases[0];
+        Point[] samplePoint = new Point[1];
+        SwingUtilities.invokeAndWait(() -> {
+            state.frame.toFront();
+            Point location = canvas.getLocationOnScreen();
+            samplePoint[0] = new Point(
+                    location.x + canvas.getWidth() / 2,
+                    location.y + canvas.getHeight() / 2);
+        });
+
+        Robot robot = new Robot();
+        long deadline = System.nanoTime() + 5_000_000_000L;
+        Color actual;
+        do {
+            renderCanvases(state);
+            robot.waitForIdle();
+            robot.delay(20);
+            actual = robot.getPixelColor(samplePoint[0].x, samplePoint[0].y);
+            if (screenColorComponentMatches(64, actual.getRed())
+                    && screenColorComponentMatches(128, actual.getGreen())
+                    && screenColorComponentMatches(191, actual.getBlue())) {
+                return;
+            }
+        } while (System.nanoTime() < deadline);
+        fail("Expected the compositor to present RGB near [64, 128, 191] but sampled "
+                + actual.getRed() + ", " + actual.getGreen() + ", " + actual.getBlue());
+    }
+
+    private static boolean screenColorComponentMatches(int expected, int actual) {
+        // Robot reads display-managed pixels. Display P3 conversion can shift an individual channel noticeably,
+        // while the front-buffer test above remains the exact, color-space-independent swap assertion.
+        return Math.abs(expected - actual) <= 40;
+    }
+
     private static double[] expectedLayerFrame(TestCanvas canvas) throws Exception {
         double[][] result = new double[1][];
         SwingUtilities.invokeAndWait(() -> {
@@ -558,6 +643,10 @@ class MacOSXGLCanvasLifecycleTest {
         int surfaceBackingWidth;
         int surfaceBackingHeight;
         int configuredSwapInterval;
+        int actualMajorVersion;
+        int actualMinorVersion;
+        int actualProfileMask;
+        int actualContextFlags;
         final boolean verifyPresentation;
         final int[] frontPixel = new int[4];
 
@@ -578,6 +667,15 @@ class MacOSXGLCanvasLifecycleTest {
         @Override
         public void initGL() {
             GL.createCapabilities();
+            APIVersion actualVersion = APIUtil.apiParseVersion(glGetString(GL_VERSION));
+            actualMajorVersion = actualVersion.major;
+            actualMinorVersion = actualVersion.minor;
+            if (GLUtil.atLeast32(actualMajorVersion, actualMinorVersion)) {
+                actualProfileMask = glGetInteger(GL_CONTEXT_PROFILE_MASK);
+            }
+            if (GLUtil.atLeast30(actualMajorVersion, actualMinorVersion)) {
+                actualContextFlags = glGetInteger(GL_CONTEXT_FLAGS);
+            }
             int[] enabled = new int[1];
             assertEquals(kCGLNoError, CGLIsEnabled(context, kCGLCESurfaceBackingSize, enabled));
             surfaceBackingSizeEnabled = enabled[0] != 0;

--- a/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
@@ -3,6 +3,7 @@ package org.lwjgl.opengl.awt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.opengl.GL;
 import org.lwjgl.system.JNI;
@@ -27,10 +28,10 @@ import java.nio.ByteBuffer;
 
 import static java.nio.ByteOrder.nativeOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.lwjgl.opengl.CGL.CGLDisable;
 import static org.lwjgl.system.MemoryUtil.memAddress;
 import static org.lwjgl.system.libffi.LibFFI.FFI_DEFAULT_ABI;
 import static org.lwjgl.system.libffi.LibFFI.FFI_OK;
@@ -41,11 +42,24 @@ import static org.lwjgl.system.libffi.LibFFI.ffi_type_double;
 import static org.lwjgl.system.libffi.LibFFI.ffi_type_pointer;
 import static org.lwjgl.system.libffi.LibFFI.ffi_type_void;
 import static org.lwjgl.system.macosx.ObjCRuntime.sel_getUid;
+import static org.lwjgl.opengl.CGL.CGLDisable;
 import static org.lwjgl.opengl.CGL.CGLGetParameter;
 import static org.lwjgl.opengl.CGL.CGLIsEnabled;
 import static org.lwjgl.opengl.CGL.kCGLCESurfaceBackingSize;
+import static org.lwjgl.opengl.CGL.kCGLCPSwapInterval;
 import static org.lwjgl.opengl.CGL.kCGLCPSurfaceBackingSize;
 import static org.lwjgl.opengl.CGL.kCGLNoError;
+import static org.lwjgl.opengl.GL11.GL_BACK;
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_FRONT;
+import static org.lwjgl.opengl.GL11.GL_RGBA;
+import static org.lwjgl.opengl.GL11.GL_UNSIGNED_BYTE;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.lwjgl.opengl.GL11.glClearColor;
+import static org.lwjgl.opengl.GL11.glDrawBuffer;
+import static org.lwjgl.opengl.GL11.glFinish;
+import static org.lwjgl.opengl.GL11.glReadBuffer;
+import static org.lwjgl.opengl.GL11.glReadPixels;
 
 @EnabledOnOs(OS.MAC)
 class MacOSXGLCanvasLifecycleTest {
@@ -132,6 +146,66 @@ class MacOSXGLCanvasLifecycleTest {
     }
 
     @Test
+    void appliesSwapIntervalAndPopulatesEffectiveData() throws Exception {
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 2;
+        data.profile = GLData.Profile.CORE;
+        data.doubleBuffer = true;
+        data.swapInterval = 0;
+        data.stencilSize = 8;
+
+        FrameState state = showConfiguredCanvas(data);
+        try {
+            renderCanvases(state);
+            TestCanvas canvas = state.canvases[0];
+            assertEquals(0, canvas.configuredSwapInterval);
+            assertEquals(Integer.valueOf(0), canvas.effective.swapInterval);
+            assertEquals(GLData.API.GL, canvas.effective.api);
+            assertEquals(GLData.Profile.CORE, canvas.effective.profile);
+            assertTrue(canvas.effective.majorVersion >= 3);
+            assertEquals(8, canvas.effective.redSize);
+            assertEquals(8, canvas.effective.greenSize);
+            assertEquals(8, canvas.effective.blueSize);
+            assertEquals(8, canvas.effective.alphaSize);
+            assertTrue(canvas.effective.stencilSize >= 8);
+            assertTrue(canvas.effective.doubleBuffer);
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
+
+    @Test
+    void honorsSingleBufferedPixelFormat() throws Exception {
+        GLData data = new GLData();
+        data.doubleBuffer = false;
+
+        FrameState state = showConfiguredCanvas(data);
+        try {
+            renderCanvases(state);
+            assertFalse(state.canvases[0].effective.doubleBuffer);
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
+
+    @Test
+    void presentsDoubleBufferedFrame() throws Exception {
+        GLData data = new GLData();
+        data.doubleBuffer = true;
+        data.swapInterval = 0;
+
+        FrameState state = showPresentingCanvas(data);
+        try {
+            assertPresentedFrameEventually(state);
+            TestCanvas canvas = state.canvases[0];
+            assertTrue(canvas.effective.doubleBuffer);
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
+
+    @Test
     void updatesNativeLayerFrameWhenCanvasMovesInsideRootPane() throws Exception {
         FrameState state = showMovableCanvas();
         try {
@@ -214,6 +288,36 @@ class MacOSXGLCanvasLifecycleTest {
         return result[0];
     }
 
+    private static FrameState showConfiguredCanvas(GLData data) throws Exception {
+        FrameState[] result = new FrameState[1];
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame("macOS configured OpenGL canvas");
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            TestCanvas canvas = new TestCanvas(data);
+            canvas.setPreferredSize(new Dimension(160, 120));
+            frame.add(canvas);
+            frame.pack();
+            frame.setVisible(true);
+            result[0] = new FrameState(frame, new TestCanvas[]{canvas});
+        });
+        return result[0];
+    }
+
+    private static FrameState showPresentingCanvas(GLData data) throws Exception {
+        FrameState[] result = new FrameState[1];
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame("macOS double-buffer presentation");
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            TestCanvas canvas = new TestCanvas(data, true);
+            canvas.setPreferredSize(new Dimension(160, 120));
+            frame.add(canvas);
+            frame.pack();
+            frame.setVisible(true);
+            result[0] = new FrameState(frame, new TestCanvas[]{canvas});
+        });
+        return result[0];
+    }
+
     private static FrameState showSplitCanvases() throws Exception {
         FrameState[] result = new FrameState[1];
         SwingUtilities.invokeAndWait(() -> {
@@ -263,6 +367,35 @@ class MacOSXGLCanvasLifecycleTest {
                 canvas.render();
             }
         });
+    }
+
+    private static void assertColorComponent(int expected, int actual, String component) {
+        assertTrue(Math.abs(expected - actual) <= 1,
+                "Expected " + component + " component near " + expected + " but was " + actual);
+    }
+
+    private static void assertPresentedFrameEventually(FrameState state) throws Exception {
+        TestCanvas canvas = state.canvases[0];
+        long deadline = System.nanoTime() + 5_000_000_000L;
+        do {
+            renderCanvases(state);
+            if (colorComponentMatches(64, canvas.frontPixel[0])
+                    && colorComponentMatches(128, canvas.frontPixel[1])
+                    && colorComponentMatches(191, canvas.frontPixel[2])
+                    && colorComponentMatches(255, canvas.frontPixel[3])) {
+                return;
+            }
+            Thread.sleep(10L);
+        } while (System.nanoTime() < deadline);
+
+        assertColorComponent(64, canvas.frontPixel[0], "red");
+        assertColorComponent(128, canvas.frontPixel[1], "green");
+        assertColorComponent(191, canvas.frontPixel[2], "blue");
+        assertColorComponent(255, canvas.frontPixel[3], "alpha");
+    }
+
+    private static boolean colorComponentMatches(int expected, int actual) {
+        return Math.abs(expected - actual) <= 1;
     }
 
     private static double[] expectedLayerFrame(TestCanvas canvas) throws Exception {
@@ -424,6 +557,23 @@ class MacOSXGLCanvasLifecycleTest {
         boolean surfaceBackingSizeEnabled;
         int surfaceBackingWidth;
         int surfaceBackingHeight;
+        int configuredSwapInterval;
+        final boolean verifyPresentation;
+        final int[] frontPixel = new int[4];
+
+        TestCanvas() {
+            verifyPresentation = false;
+        }
+
+        TestCanvas(GLData data) {
+            super(data);
+            verifyPresentation = false;
+        }
+
+        TestCanvas(GLData data, boolean verifyPresentation) {
+            super(data);
+            this.verifyPresentation = verifyPresentation;
+        }
 
         @Override
         public void initGL() {
@@ -436,10 +586,38 @@ class MacOSXGLCanvasLifecycleTest {
             assertEquals(kCGLNoError, CGLGetParameter(context, kCGLCPSurfaceBackingSize, size));
             surfaceBackingWidth = size[0];
             surfaceBackingHeight = size[1];
+
+            int[] swapInterval = new int[1];
+            assertEquals(kCGLNoError, CGLGetParameter(context, kCGLCPSwapInterval, swapInterval));
+            configuredSwapInterval = swapInterval[0];
         }
 
         @Override
         public void paintGL() {
+            if (verifyPresentation) {
+                glDrawBuffer(GL_FRONT);
+                glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+                glClear(GL_COLOR_BUFFER_BIT);
+                glFinish();
+
+                glDrawBuffer(GL_BACK);
+                glClearColor(0.25f, 0.5f, 0.75f, 1.0f);
+                glClear(GL_COLOR_BUFFER_BIT);
+                swapBuffers();
+                // CGLFlushDrawable schedules the swap; finish before inspecting the new front buffer.
+                glFinish();
+
+                glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
+                glClear(GL_COLOR_BUFFER_BIT);
+
+                ByteBuffer pixel = BufferUtils.createByteBuffer(4);
+                glReadBuffer(GL_FRONT);
+                glReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixel);
+                for (int i = 0; i < frontPixel.length; i++) {
+                    frontPixel[i] = pixel.get(i) & 0xFF;
+                }
+                return;
+            }
             swapBuffers();
         }
     }

--- a/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
@@ -24,11 +24,9 @@ import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
 import java.awt.AWTException;
 import java.awt.Canvas;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.IllegalComponentStateException;
 import java.awt.Point;
-import java.awt.Robot;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 
@@ -241,21 +239,6 @@ class MacOSXGLCanvasLifecycleTest {
     }
 
     @Test
-    void presentsDoubleBufferedFrameThroughWindowCompositor() throws Exception {
-        GLData data = new GLData();
-        data.doubleBuffer = true;
-        data.swapInterval = 0;
-
-        FrameState state = showPresentingCanvas(data);
-        try {
-            assertPresentedFrameEventually(state);
-            assertCompositedFrameEventually(state);
-        } finally {
-            SwingUtilities.invokeAndWait(state.frame::dispose);
-        }
-    }
-
-    @Test
     void updatesNativeLayerFrameWhenCanvasMovesInsideRootPane() throws Exception {
         FrameState state = showMovableCanvas();
         try {
@@ -446,41 +429,6 @@ class MacOSXGLCanvasLifecycleTest {
 
     private static boolean colorComponentMatches(int expected, int actual) {
         return Math.abs(expected - actual) <= 1;
-    }
-
-    private static void assertCompositedFrameEventually(FrameState state) throws Exception {
-        TestCanvas canvas = state.canvases[0];
-        Point[] samplePoint = new Point[1];
-        SwingUtilities.invokeAndWait(() -> {
-            state.frame.toFront();
-            Point location = canvas.getLocationOnScreen();
-            samplePoint[0] = new Point(
-                    location.x + canvas.getWidth() / 2,
-                    location.y + canvas.getHeight() / 2);
-        });
-
-        Robot robot = new Robot();
-        long deadline = System.nanoTime() + 5_000_000_000L;
-        Color actual;
-        do {
-            renderCanvases(state);
-            robot.waitForIdle();
-            robot.delay(20);
-            actual = robot.getPixelColor(samplePoint[0].x, samplePoint[0].y);
-            if (screenColorComponentMatches(64, actual.getRed())
-                    && screenColorComponentMatches(128, actual.getGreen())
-                    && screenColorComponentMatches(191, actual.getBlue())) {
-                return;
-            }
-        } while (System.nanoTime() < deadline);
-        fail("Expected the compositor to present RGB near [64, 128, 191] but sampled "
-                + actual.getRed() + ", " + actual.getGreen() + ", " + actual.getBlue());
-    }
-
-    private static boolean screenColorComponentMatches(int expected, int actual) {
-        // Robot reads display-managed pixels. Display P3 conversion can shift an individual channel noticeably,
-        // while the front-buffer test above remains the exact, color-space-independent swap assertion.
-        return Math.abs(expected - actual) <= 40;
     }
 
     private static double[] expectedLayerFrame(TestCanvas canvas) throws Exception {

--- a/test/org/lwjgl/opengl/awt/MacOSXGLDataUtilTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLDataUtilTest.java
@@ -1,0 +1,154 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.AWTException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_ACCELERATED;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_ACCUM_SIZE;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_ALPHA_SIZE;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_COLOR_FLOAT;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_COLOR_SIZE;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_DEPTH_SIZE;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_DOUBLE_BUFFER;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_OPENGL_PROFILE;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_SAMPLE_BUFFERS;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_SAMPLES;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_STENCIL_SIZE;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_STEREO;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PROFILE_4_1_CORE;
+
+class MacOSXGLDataUtilTest {
+
+    @Test
+    void encodesDoubleBufferAndCoreProfileExactlyOnce() {
+        GLData data = new GLData();
+        data.majorVersion = 4;
+        data.minorVersion = 1;
+        data.profile = GLData.Profile.CORE;
+        data.doubleBuffer = true;
+
+        int[] attributes = MacOSXGLDataUtil.createPixelFormatAttributes(data, true, true);
+
+        assertTrue(contains(attributes, NS_OPENGL_PFA_DOUBLE_BUFFER));
+        assertTrue(containsPair(attributes, NS_OPENGL_PFA_COLOR_SIZE, 32));
+        assertEquals(1, count(attributes, NS_OPENGL_PFA_OPENGL_PROFILE));
+        assertTrue(containsPair(attributes, NS_OPENGL_PFA_OPENGL_PROFILE, NS_OPENGL_PROFILE_4_1_CORE));
+    }
+
+    @Test
+    void omitsDoubleBufferWhenSingleBufferingIsRequested() {
+        GLData data = new GLData();
+        data.doubleBuffer = false;
+
+        int[] attributes = MacOSXGLDataUtil.createPixelFormatAttributes(data, true, true);
+
+        assertFalse(contains(attributes, NS_OPENGL_PFA_DOUBLE_BUFFER));
+    }
+
+    @Test
+    void retriesWithRelaxedOptionalAttributes() throws Exception {
+        GLData data = new GLData();
+        data.stereo = true;
+        data.samples = 16;
+        List<int[]> attempts = new ArrayList<>();
+
+        MacOSXGLDataUtil.PixelFormatSelection selection = MacOSXGLDataUtil.choosePixelFormat(data, attributes -> {
+            attempts.add(attributes);
+            return attempts.size() == 2 ? 42L : 0L;
+        });
+
+        assertEquals(42L, selection.pixelFormat);
+        assertEquals(2, attempts.size());
+        assertTrue(contains(attempts.get(0), NS_OPENGL_PFA_STEREO));
+        assertTrue(contains(attempts.get(0), NS_OPENGL_PFA_SAMPLES));
+        assertFalse(contains(attempts.get(1), NS_OPENGL_PFA_STEREO));
+        assertTrue(contains(attempts.get(1), NS_OPENGL_PFA_SAMPLES));
+        assertSame(attempts.get(1), selection.attributes);
+    }
+
+    @Test
+    void relaxesMostExoticAttributesFirst() {
+        GLData data = new GLData();
+        data.stereo = true;
+        data.pixelFormatFloat = true;
+        data.accumRedSize = 8;
+        data.samples = 4;
+
+        List<int[]> candidates = MacOSXGLDataUtil.createPixelFormatCandidates(data);
+
+        assertEquals(6, candidates.size());
+        assertTrue(contains(candidates.get(0), NS_OPENGL_PFA_STEREO));
+        assertTrue(contains(candidates.get(0), NS_OPENGL_PFA_COLOR_FLOAT));
+        assertTrue(contains(candidates.get(0), NS_OPENGL_PFA_ACCUM_SIZE));
+        assertTrue(contains(candidates.get(0), NS_OPENGL_PFA_SAMPLES));
+
+        assertFalse(contains(candidates.get(1), NS_OPENGL_PFA_STEREO));
+        assertTrue(contains(candidates.get(1), NS_OPENGL_PFA_COLOR_FLOAT));
+        assertFalse(contains(candidates.get(2), NS_OPENGL_PFA_COLOR_FLOAT));
+        assertTrue(contains(candidates.get(2), NS_OPENGL_PFA_ACCUM_SIZE));
+        assertFalse(contains(candidates.get(3), NS_OPENGL_PFA_ACCUM_SIZE));
+        assertTrue(contains(candidates.get(3), NS_OPENGL_PFA_SAMPLES));
+        assertFalse(contains(candidates.get(4), NS_OPENGL_PFA_SAMPLES));
+        assertTrue(contains(candidates.get(4), NS_OPENGL_PFA_ACCELERATED));
+        assertFalse(contains(candidates.get(5), NS_OPENGL_PFA_ACCELERATED));
+    }
+
+    @Test
+    void reportsPixelFormatFailureAsAwtException() {
+        AWTException exception = assertThrows(AWTException.class,
+                () -> MacOSXGLDataUtil.choosePixelFormat(new GLData(), attributes -> 0L));
+
+        assertTrue(exception.getMessage().contains("2 attempts"));
+    }
+
+    private static boolean contains(int[] values, int expected) {
+        return count(values, expected) > 0;
+    }
+
+    private static int count(int[] values, int expected) {
+        int count = 0;
+        for (int i = 0; i < values.length && values[i] != 0;) {
+            int attribute = values[i++];
+            if (attribute == expected) {
+                count++;
+            }
+            if (hasValue(attribute)) {
+                i++;
+            }
+        }
+        return count;
+    }
+
+    private static boolean containsPair(int[] values, int first, int second) {
+        for (int i = 0; i < values.length && values[i] != 0;) {
+            int attribute = values[i++];
+            if (!hasValue(attribute)) {
+                continue;
+            }
+            int value = values[i++];
+            if (attribute == first && value == second) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasValue(int attribute) {
+        return attribute == NS_OPENGL_PFA_COLOR_SIZE
+                || attribute == NS_OPENGL_PFA_ALPHA_SIZE
+                || attribute == NS_OPENGL_PFA_DEPTH_SIZE
+                || attribute == NS_OPENGL_PFA_STENCIL_SIZE
+                || attribute == NS_OPENGL_PFA_ACCUM_SIZE
+                || attribute == NS_OPENGL_PFA_SAMPLE_BUFFERS
+                || attribute == NS_OPENGL_PFA_SAMPLES
+                || attribute == NS_OPENGL_PFA_OPENGL_PROFILE;
+    }
+}

--- a/test/org/lwjgl/opengl/awt/MacOSXGLDataUtilTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLDataUtilTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.awt.AWTException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -107,6 +108,49 @@ class MacOSXGLDataUtilTest {
                 () -> MacOSXGLDataUtil.choosePixelFormat(new GLData(), attributes -> 0L));
 
         assertTrue(exception.getMessage().contains("2 attempts"));
+    }
+
+    @Test
+    void mapsOpenGL33RequestToTheNextSupportedCoreProfile() {
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 3;
+        data.profile = GLData.Profile.CORE;
+
+        assertEquals(NS_OPENGL_PROFILE_4_1_CORE, MacOSXGLDataUtil.profileAttribute(data));
+    }
+
+    @Test
+    void rejectsOptionsThatNSOpenGLCannotHonor() {
+        assertUnsupported(data -> data.api = GLData.API.GLES, "OpenGL ES");
+        assertUnsupported(data -> data.debug = true, "debug");
+        assertUnsupported(data -> data.sRGB = true, "sRGB");
+        assertUnsupported(data -> data.contextReleaseBehavior = GLData.ReleaseBehavior.NONE, "release behavior");
+        assertUnsupported(data -> {
+            data.samples = 4;
+            data.colorSamplesNV = 2;
+        }, "coverage sampling");
+        assertUnsupported(data -> data.swapGroupNV = 1, "swap groups");
+        assertUnsupported(data -> data.robustness = true, "robustness");
+        assertUnsupported(data -> {
+            data.majorVersion = 3;
+            data.minorVersion = 2;
+            data.profile = GLData.Profile.COMPATIBILITY;
+        }, "compatibility profiles");
+        assertUnsupported(data -> {
+            data.majorVersion = 4;
+            data.minorVersion = 2;
+        }, "up to 4.1");
+    }
+
+    private static void assertUnsupported(Consumer<GLData> configuration, String messageFragment) {
+        GLData data = new GLData();
+        configuration.accept(data);
+
+        AWTException failure = assertThrows(AWTException.class,
+                () -> MacOSXGLDataUtil.validateAttributes(data));
+
+        assertTrue(failure.getMessage().contains(messageFragment));
     }
 
     private static boolean contains(int[] values, int expected) {

--- a/test/org/lwjgl/opengl/awt/RobotScreenCaptureCondition.java
+++ b/test/org/lwjgl/opengl/awt/RobotScreenCaptureCondition.java
@@ -1,0 +1,141 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lwjgl.system.JNI;
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.system.Platform;
+import org.lwjgl.system.SharedLibrary;
+import org.lwjgl.system.macosx.MacOSXLibrary;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Locale;
+
+/**
+ * Enables Robot screen-capture tests where they are safe to run.
+ *
+ * <p>Linux and Windows retain their normal coverage. macOS defaults to {@code off}, because direct capture can
+ * display privacy UI on unattended machines. On macOS 14 and earlier, set {@value #MODE_PROPERTY} to {@code auto}
+ * to run only when the Core Graphics permission preflight succeeds. Set it to {@code required} on an explicitly
+ * authorized machine to make a missing permission a test error. The preflight never requests the normal
+ * screen-capture permission; required mode assumes any macOS 15+ private-picker allowance is already granted.</p>
+ */
+public final class RobotScreenCaptureCondition implements ExecutionCondition {
+
+    static final String MODE_PROPERTY = "lwjgl3.awt.robotScreenshots";
+
+    private static final ConditionEvaluationResult ENABLED =
+            ConditionEvaluationResult.enabled("Robot screen capture is available");
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Platform platform = Platform.get();
+        if (platform == Platform.LINUX || platform == Platform.WINDOWS) {
+            return ENABLED;
+        }
+        if (platform != Platform.MACOSX) {
+            return ConditionEvaluationResult.disabled("Robot screenshot tests support Linux, macOS and Windows");
+        }
+
+        Mode mode = parseMode(System.getProperty(MODE_PROPERTY, Mode.OFF.name()));
+        if (mode == Mode.OFF) {
+            return ConditionEvaluationResult.disabled(
+                    "macOS Robot screenshots are disabled; use -Pmacos-robot-screenshots on an authorized Mac");
+        }
+        if (mode == Mode.AUTO && hasPrivateWindowPicker()) {
+            // macOS 15 added a separate, monthly authorization for bypassing its content picker. There is no
+            // public preflight for that authorization, so automatic capture would risk opening privacy UI.
+            return ConditionEvaluationResult.disabled(
+                    "macOS 15+ Robot screenshots require explicit opt-in with -Pmacos-robot-screenshots");
+        }
+
+        PermissionCheck permission = MacOSPermissionHolder.PERMISSION;
+        if (permission.granted) {
+            return ENABLED;
+        }
+
+        String message = "macOS screen-capture permission is not available to this process"
+                + (permission.failure == null ? "" : ": " + permission.failure);
+        if (mode == Mode.REQUIRED) {
+            throw new ExtensionConfigurationException(message
+                    + ". Grant Screen & System Audio Recording access, restart the process, and retry.");
+        }
+        return ConditionEvaluationResult.disabled(message);
+    }
+
+    static Mode parseMode(String value) {
+        try {
+            return Mode.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new ExtensionConfigurationException(
+                    "Invalid " + MODE_PROPERTY + " value '" + value + "'; expected off, auto or required",
+                    exception);
+        }
+    }
+
+    enum Mode {
+        OFF,
+        AUTO,
+        REQUIRED
+    }
+
+    private static boolean hasPrivateWindowPicker() {
+        return hasPrivateWindowPicker(System.getProperty("os.version", ""));
+    }
+
+    static boolean hasPrivateWindowPicker(String version) {
+        String[] components = version.split("\\.", 3);
+        try {
+            int major = Integer.parseInt(components[0]);
+            if (major >= 15) {
+                return true;
+            }
+            // Older runtimes may report 10.16 for any post-Catalina macOS release. Treat it conservatively,
+            // because the real system version cannot be determined safely from this process.
+            return major == 10 && components.length > 1 && Integer.parseInt(components[1]) >= 16;
+        } catch (NumberFormatException exception) {
+            // Be conservative if a future runtime changes the version format.
+            return true;
+        }
+    }
+
+    private static PermissionCheck preflightMacOSPermission() {
+        try (SharedLibrary coreGraphics =
+                     MacOSXLibrary.create("/System/Library/Frameworks/CoreGraphics.framework")) {
+            long preflight = coreGraphics.getFunctionAddress("CGPreflightScreenCaptureAccess");
+            if (preflight == MemoryUtil.NULL) {
+                // The preflight API was introduced together with screen-capture permission on macOS 10.15.
+                return new PermissionCheck(true, null);
+            }
+            return new PermissionCheck(JNI.invokeI(preflight) != 0, null);
+        } catch (RuntimeException | UnsatisfiedLinkError exception) {
+            return new PermissionCheck(false, exception.getMessage());
+        }
+    }
+
+    private static final class MacOSPermissionHolder {
+        private static final PermissionCheck PERMISSION = preflightMacOSPermission();
+    }
+
+    private static final class PermissionCheck {
+        private final boolean granted;
+        private final String failure;
+
+        private PermissionCheck(boolean granted, String failure) {
+            this.granted = granted;
+            this.failure = failure;
+        }
+    }
+}
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(RobotScreenCaptureCondition.class)
+@interface EnabledForRobotScreenCapture {
+}

--- a/test/org/lwjgl/opengl/awt/RobotScreenCaptureConditionTest.java
+++ b/test/org/lwjgl/opengl/awt/RobotScreenCaptureConditionTest.java
@@ -1,0 +1,34 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RobotScreenCaptureConditionTest {
+
+    @Test
+    void parsesScreenCaptureModes() {
+        assertEquals(RobotScreenCaptureCondition.Mode.OFF,
+                RobotScreenCaptureCondition.parseMode("off"));
+        assertEquals(RobotScreenCaptureCondition.Mode.AUTO,
+                RobotScreenCaptureCondition.parseMode(" Auto "));
+        assertEquals(RobotScreenCaptureCondition.Mode.REQUIRED,
+                RobotScreenCaptureCondition.parseMode("REQUIRED"));
+        assertThrows(ExtensionConfigurationException.class,
+                () -> RobotScreenCaptureCondition.parseMode("enabled"));
+    }
+
+    @Test
+    void recognizesSystemsWhosePrivatePickerCannotBePreflighted() {
+        assertFalse(RobotScreenCaptureCondition.hasPrivateWindowPicker("10.15.7"));
+        assertFalse(RobotScreenCaptureCondition.hasPrivateWindowPicker("14.7.6"));
+        assertTrue(RobotScreenCaptureCondition.hasPrivateWindowPicker("15.0"));
+        assertTrue(RobotScreenCaptureCondition.hasPrivateWindowPicker("26.1"));
+        assertTrue(RobotScreenCaptureCondition.hasPrivateWindowPicker("10.16"));
+        assertTrue(RobotScreenCaptureCondition.hasPrivateWindowPicker("unknown"));
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Follows #133, #132, and #131, which have all been merged.

The macOS backend did not fully honor `GLData`: it effectively created single-buffered contexts, used `glFlush` as its swap operation, ignored swap intervals, left `effective` mostly unpopulated, and could emit duplicate profile attributes. Pixel-format creation also failed immediately when optional constraints were unsupported.

The backend now honors single- and double-buffer requests, presents double-buffered contexts with `CGLFlushDrawable`, applies and reports the swap interval, and queries the effective pixel-format and context values. Pixel-format creation progressively relaxes optional attributes while retaining required buffering and profile settings, and unsupported requests are rejected instead of silently ignored.

Tests cover attribute encoding and fallback, effective values, swap intervals, single and double buffering, and front-buffer presentation. End-to-end Robot capture is available through the `macos-robot-screenshots` Maven profile. It is disabled by default and in unattended CI so normal test runs do not trigger the macOS authorization dialog reported in #95.
