### PR TITLE
Add JDK 17 and 21 lifecycle smoke coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  MESA_VERSION: '26.1.4'
+  MESA_SHA256: '3804c66059c17b7ce12ca8596782585547e20c2185938f89663ec7b807ef0a84'
+
 jobs:
   test-linux:
     name: Test on Linux (${{ matrix.arch }})
@@ -46,7 +50,10 @@ jobs:
     - name: Install Dependencies
       timeout-minutes: 5
       run: |
-        sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+        sudo env \
+          DEBIAN_FRONTEND=noninteractive \
+          NEEDRESTART_SUSPEND=1 \
+          apt-get \
           -o Acquire::Retries=3 \
           -o Acquire::http::Timeout=30 \
           -o Acquire::https::Timeout=30 \
@@ -56,6 +63,8 @@ jobs:
           libglx-mesa0 \
           mesa-utils \
           x11-utils \
+          xauth \
+          xfonts-base \
           xvfb
     - name: Build with Maven
       run: |
@@ -73,6 +82,7 @@ jobs:
           exit 1
         fi
         echo "Xvfb is running."
+        glxinfo -B
 
         ./mvnw -B test
     - name: Upload Images
@@ -121,9 +131,6 @@ jobs:
       - name: Register Mesa as the OpenGL driver
         if: matrix.mesa
         shell: pwsh
-        env:
-          MESA_VERSION: '26.1.4'
-          MESA_SHA256: '3804c66059c17b7ce12ca8596782585547e20c2185938f89663ec7b807ef0a84'
         run: |
           $ErrorActionPreference = 'Stop'
           $archive = Join-Path $env:RUNNER_TEMP 'mesa.7z'
@@ -291,7 +298,10 @@ jobs:
         if: runner.os == 'Linux'
         timeout-minutes: 5
         run: |
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+          sudo env \
+            DEBIAN_FRONTEND=noninteractive \
+            NEEDRESTART_SUSPEND=1 \
+            apt-get \
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \
@@ -301,13 +311,12 @@ jobs:
             libglx-mesa0 \
             mesa-utils \
             x11-utils \
+            xauth \
+            xfonts-base \
             xvfb
       - name: Register Mesa as the OpenGL driver
         if: runner.os == 'Windows'
         shell: pwsh
-        env:
-          MESA_VERSION: '26.1.4'
-          MESA_SHA256: '3804c66059c17b7ce12ca8596782585547e20c2185938f89663ec7b807ef0a84'
         run: |
           $ErrorActionPreference = 'Stop'
           $archive = Join-Path $env:RUNNER_TEMP 'mesa.7z'
@@ -345,13 +354,31 @@ jobs:
             echo "::error::Xvfb did not become ready within 10 seconds"
             exit 1
           fi
+          glxinfo -B
           ./mvnw -B -Dtest=JAWTDrawingSurfaceThreadLifetimeTest test
-      - name: Run repeated lifecycle smoke (Windows and macOS)
-        if: runner.os != 'Linux'
+      - name: Run repeated lifecycle smoke (Windows)
+        if: runner.os == 'Windows'
         run: ./mvnw -B -Dtest=JAWTDrawingSurfaceThreadLifetimeTest test
         env:
           GALLIUM_DRIVER: llvmpipe
           LIBGL_ALWAYS_SOFTWARE: '1'
+      - name: Run repeated lifecycle smoke (macOS)
+        if: runner.os == 'macOS'
+        run: ./mvnw -B -Dtest=JAWTDrawingSurfaceThreadLifetimeTest test
+      - name: Collect macOS smoke diagnostics
+        if: failure() && runner.os == 'macOS'
+        run: |
+          mkdir -p smoke-crash-logs
+          cp -v replay_pid*.log smoke-crash-logs/ 2>/dev/null || true
+          cp -v target/replay_pid*.log smoke-crash-logs/ 2>/dev/null || true
+          if [ -d "$HOME/Library/Logs/DiagnosticReports" ]; then
+            cp -rv "$HOME/Library/Logs/DiagnosticReports" \
+              smoke-crash-logs/user-DiagnosticReports 2>/dev/null || true
+          fi
+          if [ -d /Library/Logs/DiagnosticReports ]; then
+            sudo cp -rv /Library/Logs/DiagnosticReports \
+              smoke-crash-logs/system-DiagnosticReports 2>/dev/null || true
+          fi
       - name: Upload smoke diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -360,5 +387,8 @@ jobs:
           path: |
             hs_err_pid*.log
             target/hs_err_pid*.log
+            replay_pid*.log
+            target/replay_pid*.log
+            smoke-crash-logs/
             target/surefire-reports/
           if-no-files-found: warn

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -215,3 +215,114 @@ jobs:
           name: crash-logs-macos-${{ matrix.arch }}
           path: 'crash-logs/'
           if-no-files-found: warn
+  smoke-modern-jdks:
+    name: Smoke on ${{ matrix.os_name }} (JDK ${{ matrix.java_version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_name: Linux
+            artifact_os: linux
+            runner: ubuntu-24.04
+            java_version: '17'
+          - os_name: Linux
+            artifact_os: linux
+            runner: ubuntu-24.04
+            java_version: '21'
+          - os_name: Windows
+            artifact_os: windows
+            runner: windows-2025
+            java_version: '17'
+          - os_name: Windows
+            artifact_os: windows
+            runner: windows-2025
+            java_version: '21'
+          - os_name: macOS
+            artifact_os: macos
+            runner: macos-15-intel
+            java_version: '17'
+          - os_name: macOS
+            artifact_os: macos
+            runner: macos-15-intel
+            java_version: '21'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: ${{ matrix.java_version }}
+          distribution: 'zulu'
+          architecture: x64
+          cache: maven
+      - name: Update Package Information
+        if: runner.os == 'Linux'
+        run: sudo apt-get update
+      - name: Install Dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y git xvfb x11-utils mesa*
+      - name: Register Mesa as the OpenGL driver
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          MESA_VERSION: '26.1.4'
+          MESA_SHA256: '3804c66059c17b7ce12ca8596782585547e20c2185938f89663ec7b807ef0a84'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $archive = Join-Path $env:RUNNER_TEMP 'mesa.7z'
+          $extracted = Join-Path $env:RUNNER_TEMP 'mesa'
+          $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$env:MESA_VERSION/mesa3d-$env:MESA_VERSION-release-msvc.7z"
+          curl.exe --fail --location --retry 5 --retry-all-errors --retry-delay 10 --output "$archive" "$url"
+          $hash = (Get-FileHash "$archive" -Algorithm SHA256).Hash
+          if ($hash -ne $env:MESA_SHA256.ToUpper()) {
+            throw "Mesa checksum mismatch: expected $env:MESA_SHA256, got $hash"
+          }
+          7z x "$archive" "-o$extracted" 'x64\libgallium_wgl.dll' 'x64\dxil.dll'
+          $system32 = Join-Path $env:SystemRoot 'System32'
+          Copy-Item (Join-Path $extracted 'x64\libgallium_wgl.dll') (Join-Path $system32 'mesadrv.dll') -Force
+          Copy-Item (Join-Path $extracted 'x64\dxil.dll') $system32 -Force
+          $key = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL'
+          New-Item -Path $key -Force | Out-Null
+          Set-ItemProperty -Path $key -Name 'DLL' -Value 'mesadrv.dll' -Type String
+          Set-ItemProperty -Path $key -Name 'DriverVersion' -Value 1 -Type DWord
+          Set-ItemProperty -Path $key -Name 'Flags' -Value 1 -Type DWord
+          Set-ItemProperty -Path $key -Name 'Version' -Value 2 -Type DWord
+          Get-Item (Join-Path $system32 'mesadrv.dll') | Format-Table Name, Length
+          Get-ItemProperty -Path $key | Format-List DLL, DriverVersion, Flags, Version
+      - name: Run repeated lifecycle smoke (Linux)
+        if: runner.os == 'Linux'
+        env:
+          GALLIUM_DRIVER: llvmpipe
+          LIBGL_ALWAYS_SOFTWARE: '1'
+        run: |
+          export XVFB_WHD="1920x1080x24"
+          export DISPLAY=":99"
+          Xvfb :99 -ac -screen 0 "$XVFB_WHD" -nolisten tcp +extension GLX +render -noreset &
+          Xvfb_pid="$!"
+          trap 'kill "$Xvfb_pid" 2>/dev/null || true' EXIT
+          if ! timeout 10s bash -c 'until xdpyinfo -display "$DISPLAY" > /dev/null 2>&1; do sleep 0.1; done'; then
+            echo "::error::Xvfb did not become ready within 10 seconds"
+            exit 1
+          fi
+          ./mvnw -B -Dtest=JAWTDrawingSurfaceThreadLifetimeTest test
+      - name: Run repeated lifecycle smoke (Windows and macOS)
+        if: runner.os != 'Linux'
+        run: ./mvnw -B -Dtest=JAWTDrawingSurfaceThreadLifetimeTest test
+        env:
+          GALLIUM_DRIVER: llvmpipe
+          LIBGL_ALWAYS_SOFTWARE: '1'
+      - name: Upload smoke diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lifecycle-smoke-${{ matrix.artifact_os }}-jdk-${{ matrix.java_version }}
+          path: |
+            hs_err_pid*.log
+            target/hs_err_pid*.log
+            target/surefire-reports/
+          if-no-files-found: warn

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,9 +36,27 @@ jobs:
         architecture: ${{ matrix.java_architecture }}
         cache: maven
     - name: Update Package Information
-      run: sudo apt-get update
+      timeout-minutes: 5
+      run: |
+        sudo apt-get \
+          -o Acquire::Retries=3 \
+          -o Acquire::http::Timeout=30 \
+          -o Acquire::https::Timeout=30 \
+          update
     - name: Install Dependencies
-      run: sudo apt-get install -y git xvfb x11-utils mesa*
+      timeout-minutes: 5
+      run: |
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+          -o Acquire::Retries=3 \
+          -o Acquire::http::Timeout=30 \
+          -o Acquire::https::Timeout=30 \
+          install -y --no-install-recommends \
+          git \
+          libgl1-mesa-dri \
+          libglx-mesa0 \
+          mesa-utils \
+          x11-utils \
+          xvfb
     - name: Build with Maven
       run: |
         export XVFB_WHD="1920x1080x24"
@@ -262,10 +280,28 @@ jobs:
           cache: maven
       - name: Update Package Information
         if: runner.os == 'Linux'
-        run: sudo apt-get update
+        timeout-minutes: 5
+        run: |
+          sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
       - name: Install Dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y git xvfb x11-utils mesa*
+        timeout-minutes: 5
+        run: |
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y --no-install-recommends \
+            git \
+            libgl1-mesa-dri \
+            libglx-mesa0 \
+            mesa-utils \
+            x11-utils \
+            xvfb
       - name: Register Mesa as the OpenGL driver
         if: runner.os == 'Windows'
         shell: pwsh

--- a/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
+++ b/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
@@ -6,13 +6,16 @@ import org.lwjgl.opengl.GL;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import java.awt.Dimension;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class JAWTDrawingSurfaceThreadLifetimeTest {
+    // Repeating the complete peer and context teardown catches resource leaks that a one-shot smoke test misses.
     private static final int LIFECYCLE_CYCLES = 10;
 
     @Test
@@ -57,19 +60,66 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
                 renderFailure.set(t);
             }
         }, "short-lived-renderer-" + cycle);
+        renderer.setDaemon(true);
+
+        renderer.start();
+        renderer.join(TimeUnit.SECONDS.toMillis(10));
+        if (renderer.isAlive()) {
+            // A stuck renderer may still hold the lifecycle lock. Do not block the EDT trying to remove the canvas,
+            // because that would hide this failure behind Surefire's fork timeout.
+            fail("Rendering thread did not exit in cycle " + cycle);
+        }
+
+        Throwable renderingFailure = renderFailure.get();
+        Throwable cleanupFailure = cleanupLifecycle(lifecycle, cycle);
+        if (renderingFailure != null) {
+            if (cleanupFailure != null && renderingFailure != cleanupFailure) {
+                renderingFailure.addSuppressed(cleanupFailure);
+            }
+            fail("Rendering failed in cycle " + cycle, renderingFailure);
+        }
+        if (cleanupFailure != null) {
+            fail("Lifecycle cleanup failed in cycle " + cycle, cleanupFailure);
+        }
+    }
+
+    private static Throwable cleanupLifecycle(Lifecycle lifecycle, int cycle) {
+        Throwable failure = null;
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                lifecycle.frame.getContentPane().remove(lifecycle.canvas);
+                assertEquals(0L, lifecycle.canvas.context,
+                        "OpenGL context was not cleared in cycle " + cycle);
+                assertFalse(lifecycle.canvas.initCalled,
+                        "Canvas remained initialized after removal in cycle " + cycle);
+            });
+        } catch (Throwable cleanupFailure) {
+            failure = unwrapInvocationFailure(cleanupFailure);
+        }
 
         try {
-            renderer.start();
-            renderer.join(TimeUnit.SECONDS.toMillis(10));
-            assertFalse(renderer.isAlive(), "Rendering thread did not exit in cycle " + cycle);
-        } finally {
-            SwingUtilities.invokeAndWait(() -> lifecycle.frame.getContentPane().remove(lifecycle.canvas));
             SwingUtilities.invokeAndWait(lifecycle.frame::dispose);
+        } catch (Throwable disposeFailure) {
+            failure = appendFailure(failure, unwrapInvocationFailure(disposeFailure));
         }
+        return failure;
+    }
 
-        if (renderFailure.get() != null) {
-            fail("Rendering failed in cycle " + cycle, renderFailure.get());
+    private static Throwable appendFailure(Throwable primary, Throwable additional) {
+        if (primary == null) {
+            return additional;
         }
+        if (primary != additional) {
+            primary.addSuppressed(additional);
+        }
+        return primary;
+    }
+
+    private static Throwable unwrapInvocationFailure(Throwable failure) {
+        if (failure instanceof InvocationTargetException && failure.getCause() != null) {
+            return failure.getCause();
+        }
+        return failure;
     }
 
     private static class Lifecycle {

--- a/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
+++ b/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
@@ -13,11 +13,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class JAWTDrawingSurfaceThreadLifetimeTest {
+    private static final int LIFECYCLE_CYCLES = 10;
 
     @Test
-    void disposesCanvasAfterRenderingThreadExits() throws Exception {
-        AtomicReference<AWTGLCanvas> canvasRef = new AtomicReference<>();
-        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+    void repeatedlyCreatesRendersRemovesAndDisposesCanvasAfterRenderingThreadExits() throws Exception {
+        for (int cycle = 0; cycle < LIFECYCLE_CYCLES; cycle++) {
+            runLifecycle(cycle);
+        }
+    }
+
+    private static void runLifecycle(int cycle) throws Exception {
+        AtomicReference<Lifecycle> lifecycleRef = new AtomicReference<>();
 
         SwingUtilities.invokeAndWait(() -> {
             AWTGLCanvas canvas = new AWTGLCanvas(new GLData()) {
@@ -33,33 +39,46 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
             };
             canvas.setPreferredSize(new Dimension(320, 240));
 
-            JFrame frame = new JFrame("dispose-after-render-thread-exits");
+            JFrame frame = new JFrame("dispose-after-render-thread-exits-" + cycle);
             frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
             frame.getContentPane().add(canvas);
             frame.pack();
             frame.setVisible(true);
 
-            canvasRef.set(canvas);
-            frameRef.set(frame);
+            lifecycleRef.set(new Lifecycle(frame, canvas));
         });
 
+        Lifecycle lifecycle = lifecycleRef.get();
         AtomicReference<Throwable> renderFailure = new AtomicReference<>();
         Thread renderer = new Thread(() -> {
             try {
-                canvasRef.get().render();
+                lifecycle.canvas.render();
             } catch (Throwable t) {
                 renderFailure.set(t);
             }
-        }, "short-lived-renderer");
-        renderer.start();
-        renderer.join(TimeUnit.SECONDS.toMillis(10));
-        assertFalse(renderer.isAlive(), "Rendering thread did not exit");
+        }, "short-lived-renderer-" + cycle);
 
-        SwingUtilities.invokeAndWait(() -> frameRef.get().getContentPane().remove(canvasRef.get()));
-        SwingUtilities.invokeAndWait(frameRef.get()::dispose);
+        try {
+            renderer.start();
+            renderer.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse(renderer.isAlive(), "Rendering thread did not exit in cycle " + cycle);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> lifecycle.frame.getContentPane().remove(lifecycle.canvas));
+            SwingUtilities.invokeAndWait(lifecycle.frame::dispose);
+        }
 
         if (renderFailure.get() != null) {
-            fail("Rendering failed", renderFailure.get());
+            fail("Rendering failed in cycle " + cycle, renderFailure.get());
+        }
+    }
+
+    private static class Lifecycle {
+        final JFrame frame;
+        final AWTGLCanvas canvas;
+
+        Lifecycle(JFrame frame, AWTGLCanvas canvas) {
+            this.frame = frame;
+            this.canvas = canvas;
         }
     }
 }


### PR DESCRIPTION
Modern JDK behavior - particularly macOS JAWT loading - was not directly protected because the main CI jobs use JDK 8. This PR adds JDK 17 and 21 smoke tests on Linux, Windows, and macOS. The tests exercise JAWT loading, OpenGL context creation, rendering, buffer swapping, canvas removal, and native disposal. This provides current regression coverage for the path reported in #64, without claiming to identify or fix that historical environment-specific failure.

This confirms that the current lwjgl3-awt runs on JDK 17 on macOS, so #64 can probably be closed as no longer reproducible; the original failure was likely specific to the reporter’s environment.