### PR TITLE
Support EGL contexts on Linux under XWayland

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,10 @@ jobs:
         echo "Xvfb is running."
 
         ./mvnw -B test
+
+        echo "Running EGL smoke test with Wayland backend selection"
+        XDG_SESSION_TYPE=wayland WAYLAND_DISPLAY=wayland-test \
+          ./mvnw -B -Dtest=LinuxEGLCanvasIntegrationTest,CompareScreenshotTest test
     - name: Upload Images
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Support for Vulkan:
 _Note about compatibility_:
 The minimum macOS version for OpenGL is 10.5, and the minimum for Vulkan is 10.11, since Vulkan runs on top of the Metal API introduced in that version.
 
+On Linux, Wayland sessions use EGL with the X11 window exposed by AWT under XWayland, matching LWJGL's default
+context API selection. Set `Configuration.OPENGL_CONTEXT_API` to `native` before LWJGL initializes OpenGL to force
+the GLX backend. This does not provide a native Wayland AWT surface.
+
 ### macOS compositor screenshot tests
 
 The end-to-end screenshot tests use `java.awt.Robot`, which requires Screen & System Audio Recording permission on

--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-egl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl-opengl</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -29,7 +29,7 @@ public abstract class AWTGLCanvas extends Canvas {
         case WINDOWS:
             return new PlatformWin32GLCanvas();
         case LINUX:
-            return new PlatformLinuxGLCanvas();
+            return PlatformLinuxGLCanvasFactory.create();
         case MACOSX:
             return new PlatformMacOSXGLCanvas();
         default:

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
@@ -1,0 +1,670 @@
+package org.lwjgl.opengl.awt;
+
+import org.lwjgl.BufferUtils;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.egl.EGL;
+import org.lwjgl.egl.EGLCapabilities;
+import org.lwjgl.opengl.ARBRobustness;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL30;
+import org.lwjgl.opengl.GL32;
+import org.lwjgl.opengl.GL43;
+import org.lwjgl.system.APIUtil;
+import org.lwjgl.system.APIUtil.APIVersion;
+import org.lwjgl.system.Checks;
+import org.lwjgl.system.JNI;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.jawt.JAWT;
+import org.lwjgl.system.jawt.JAWTDrawingSurface;
+import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
+import org.lwjgl.system.jawt.JAWTX11DrawingSurfaceInfo;
+
+import java.awt.AWTException;
+import java.awt.Canvas;
+import java.nio.IntBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.lwjgl.egl.EGL10.*;
+import static org.lwjgl.egl.EGL11.*;
+import static org.lwjgl.egl.EGL12.*;
+import static org.lwjgl.egl.EGL14.*;
+import static org.lwjgl.egl.EGL15.eglCreatePlatformWindowSurface;
+import static org.lwjgl.egl.EGL15.eglGetPlatformDisplay;
+import static org.lwjgl.egl.EXTCreateContextRobustness.*;
+import static org.lwjgl.egl.EXTPixelFormatFloat.*;
+import static org.lwjgl.egl.EXTPlatformBase.eglCreatePlatformWindowSurfaceEXT;
+import static org.lwjgl.egl.EXTPlatformBase.eglGetPlatformDisplayEXT;
+import static org.lwjgl.egl.EXTPlatformX11.*;
+import static org.lwjgl.egl.KHRContextFlushControl.*;
+import static org.lwjgl.egl.KHRCreateContext.*;
+import static org.lwjgl.egl.KHRGLColorspace.*;
+import static org.lwjgl.egl.KHRPlatformX11.*;
+import static org.lwjgl.system.MemoryUtil.*;
+import static org.lwjgl.system.jawt.JAWTFunctions.*;
+
+/**
+ * EGL implementation backed by the X11 window exposed by AWT under XWayland.
+ */
+public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
+    private static final JAWT AWT = createAWT();
+    private static final Map<Long, DisplayRef> DISPLAY_REFS = new HashMap<>();
+
+    private Canvas canvas;
+    private JAWTDrawingSurface ds;
+    private DisplayRef displayRef;
+    private long eglDisplay;
+    private long eglSurface;
+    private long eglContext;
+
+    private static JAWT createAWT() {
+        JAWT awt = JAWT.calloc();
+        awt.version(JAWT_VERSION_1_4);
+        if (!JAWT_GetAWT(awt)) {
+            throw new AssertionError("GetAWT failed");
+        }
+        return awt;
+    }
+
+    @Override
+    public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
+        GLUtil.validateAttributes(attribs);
+        validateUnsupportedAttributes(attribs);
+        this.canvas = canvas;
+
+        JAWTDrawingSurface drawingSurface = JAWT_GetDrawingSurface(canvas, AWT.GetDrawingSurface());
+        if (drawingSurface == null) {
+            throw new AWTException("Failed to get JAWT drawing surface");
+        }
+        try {
+            int lock = JAWT_DrawingSurface_Lock(drawingSurface, drawingSurface.Lock());
+            if ((lock & JAWT_LOCK_ERROR) != 0) {
+                throw new AWTException("JAWT_DrawingSurface_Lock() failed");
+            }
+            try {
+                JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(
+                        drawingSurface, drawingSurface.GetDrawingSurfaceInfo());
+                if (dsi == null) {
+                    throw new AWTException("Failed to get JAWT drawing surface information");
+                }
+                try {
+                    JAWTX11DrawingSurfaceInfo x11 = JAWTX11DrawingSurfaceInfo.create(dsi.platformInfo());
+                    return createContext(x11.display(), x11.drawable(), x11.visualID(), attribs, effective);
+                } finally {
+                    JAWT_DrawingSurface_FreeDrawingSurfaceInfo(dsi, drawingSurface.FreeDrawingSurfaceInfo());
+                }
+            } finally {
+                JAWT_DrawingSurface_Unlock(drawingSurface, drawingSurface.Unlock());
+            }
+        } finally {
+            JAWT_FreeDrawingSurface(drawingSurface, AWT.FreeDrawingSurface());
+        }
+    }
+
+    private long createContext(long nativeDisplay, long drawable, long visualID,
+            GLData attribs, GLData effective) throws AWTException {
+        int screen = org.lwjgl.system.linux.X11.XDefaultScreen(nativeDisplay);
+        displayRef = acquireDisplay(nativeDisplay, screen);
+        eglDisplay = displayRef.eglDisplay;
+
+        try {
+            validateCapabilities(attribs, displayRef.capabilities);
+            long config = chooseConfig(visualID, attribs);
+            bindClientAPI(attribs.api);
+
+            long shareContext = getShareContext(attribs);
+            eglContext = eglCreateContext(eglDisplay, config, shareContext,
+                    contextAttributes(attribs, displayRef.capabilities));
+            if (eglContext == EGL_NO_CONTEXT) {
+                throw eglFailure("Failed to create EGL context");
+            }
+
+            eglSurface = createWindowSurface(config, drawable, attribs);
+            if (eglSurface == EGL_NO_SURFACE) {
+                throw eglFailure("Failed to create EGL window surface");
+            }
+
+            if (!eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
+                throw eglFailure("Failed to make EGL context current");
+            }
+            try {
+                if (attribs.swapInterval != null) {
+                    if (!eglSwapInterval(eglDisplay, attribs.swapInterval)) {
+                        throw eglFailure("Failed to configure EGL swap interval");
+                    }
+                    effective.swapInterval = attribs.swapInterval;
+                }
+                populateEffectiveConfig(config, attribs, effective);
+                populateEffectiveGLAttributes(attribs, effective);
+            } finally {
+                eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+            }
+            return eglContext;
+        } catch (AWTException | RuntimeException | Error failure) {
+            cleanupAfterFailedCreate();
+            throw failure;
+        }
+    }
+
+    private static void validateUnsupportedAttributes(GLData data) throws AWTException {
+        if (data.stereo) {
+            throw new AWTException("Stereo rendering is unavailable with EGL window surfaces");
+        }
+        if (data.accumRedSize != 0 || data.accumGreenSize != 0
+                || data.accumBlueSize != 0 || data.accumAlphaSize != 0) {
+            throw new AWTException("Accumulation buffers are unavailable with EGL window surfaces");
+        }
+        if (data.colorSamplesNV != 0 || data.swapGroupNV != 0 || data.swapBarrierNV != 0) {
+            throw new AWTException("Requested NV framebuffer or swap features are unavailable with EGL");
+        }
+        if (data.contextResetIsolation) {
+            throw new AWTException("Context reset isolation is unavailable with EGL");
+        }
+        if (data.swapInterval != null && data.swapInterval < 0) {
+            throw new AWTException("Negative swap intervals are unavailable with EGL");
+        }
+    }
+
+    private static void validateCapabilities(GLData data, EGLCapabilities capabilities)
+            throws AWTException {
+        if (!capabilities.EGL12) {
+            throw new AWTException("EGL 1.2 or later is required");
+        }
+        if (data.api == GLData.API.GL && !capabilities.EGL14) {
+            throw new AWTException("Desktop OpenGL requires EGL 1.4 or later");
+        }
+
+        boolean createContext = capabilities.EGL15 || capabilities.EGL_KHR_create_context;
+        if (data.api == GLData.API.GL && data.majorVersion > 0 && !createContext) {
+            throw new AWTException("Versioned desktop OpenGL contexts require EGL_KHR_create_context");
+        }
+        if ((data.profile != null || data.debug || data.forwardCompatible) && !createContext) {
+            throw new AWTException("Requested OpenGL context attributes require EGL_KHR_create_context");
+        }
+        if (data.robustness && !createContext && !capabilities.EGL_EXT_create_context_robustness) {
+            throw new AWTException("Robust contexts require EGL_KHR_create_context or EGL_EXT_create_context_robustness");
+        }
+        if (data.contextReleaseBehavior != null && !capabilities.EGL_KHR_context_flush_control) {
+            throw new AWTException("Context release behavior requires EGL_KHR_context_flush_control");
+        }
+        if (data.sRGB && !capabilities.EGL_KHR_gl_colorspace) {
+            throw new AWTException("sRGB surfaces require EGL_KHR_gl_colorspace");
+        }
+        if (data.pixelFormatFloat && !capabilities.EGL_EXT_pixel_format_float) {
+            throw new AWTException("Floating-point pixel formats require EGL_EXT_pixel_format_float");
+        }
+    }
+
+    private long chooseConfig(long visualID, GLData data) throws AWTException {
+        IntBuffer attributes = BufferUtils.createIntBuffer(40);
+        attributes.put(EGL_SURFACE_TYPE).put(EGL_WINDOW_BIT);
+        attributes.put(EGL_RENDERABLE_TYPE).put(renderableType(data));
+        attributes.put(EGL_NATIVE_VISUAL_ID).put((int) visualID);
+        attributes.put(EGL_RED_SIZE).put(data.redSize);
+        attributes.put(EGL_GREEN_SIZE).put(data.greenSize);
+        attributes.put(EGL_BLUE_SIZE).put(data.blueSize);
+        attributes.put(EGL_ALPHA_SIZE).put(data.alphaSize);
+        attributes.put(EGL_DEPTH_SIZE).put(data.depthSize);
+        attributes.put(EGL_STENCIL_SIZE).put(data.stencilSize);
+        attributes.put(EGL_SAMPLE_BUFFERS).put(data.samples > 0 ? 1 : 0);
+        attributes.put(EGL_SAMPLES).put(data.samples);
+        if (data.pixelFormatFloat) {
+            attributes.put(EGL_COLOR_COMPONENT_TYPE_EXT).put(EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT);
+        }
+        attributes.put(EGL_NONE).flip();
+
+        PointerBuffer configs = BufferUtils.createPointerBuffer(1);
+        IntBuffer count = BufferUtils.createIntBuffer(1);
+        if (!eglChooseConfig(eglDisplay, attributes, configs, count)) {
+            throw eglFailure("Failed to choose EGL framebuffer configuration");
+        }
+        if (count.get(0) == 0) {
+            throw new AWTException("No EGL framebuffer configuration matches the AWT window visual");
+        }
+        return configs.get(0);
+    }
+
+    private static int renderableType(GLData data) {
+        if (data.api == GLData.API.GL) {
+            return EGL_OPENGL_BIT;
+        }
+        return data.majorVersion >= 2 ? EGL_OPENGL_ES2_BIT : EGL_OPENGL_ES_BIT;
+    }
+
+    private static void bindClientAPI(GLData.API api) throws AWTException {
+        int eglAPI = api == GLData.API.GLES ? EGL_OPENGL_ES_API : EGL_OPENGL_API;
+        if (!eglBindAPI(eglAPI)) {
+            throw eglFailure("Failed to bind EGL client API");
+        }
+    }
+
+    private long getShareContext(GLData data) throws AWTException {
+        if (data.shareContext == null) {
+            return EGL_NO_CONTEXT;
+        }
+        if (data.shareContext.context == 0L) {
+            throw new AWTException("The requested shared context has not been created");
+        }
+        if (!(data.shareContext.platformCanvas instanceof PlatformLinuxEGLCanvas)) {
+            throw new AWTException("Cannot share an EGL context with a different platform backend");
+        }
+        PlatformLinuxEGLCanvas shared = (PlatformLinuxEGLCanvas) data.shareContext.platformCanvas;
+        if (shared.eglDisplay != eglDisplay) {
+            throw new AWTException("Shared EGL contexts must use the same EGL display");
+        }
+        return data.shareContext.context;
+    }
+
+    private static IntBuffer contextAttributes(GLData data, EGLCapabilities capabilities) {
+        IntBuffer attributes = BufferUtils.createIntBuffer(32);
+        boolean createContext = capabilities.EGL15 || capabilities.EGL_KHR_create_context;
+
+        if (createContext) {
+            if (data.majorVersion > 0) {
+                attributes.put(EGL_CONTEXT_MAJOR_VERSION_KHR).put(data.majorVersion);
+                attributes.put(EGL_CONTEXT_MINOR_VERSION_KHR).put(data.minorVersion);
+            }
+
+            int flags = 0;
+            if (data.debug) {
+                flags |= EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR;
+            }
+            if (data.forwardCompatible) {
+                flags |= EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE_BIT_KHR;
+            }
+            if (data.robustness) {
+                flags |= EGL_CONTEXT_OPENGL_ROBUST_ACCESS_BIT_KHR;
+                attributes.put(EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_KHR)
+                        .put(data.loseContextOnReset
+                                ? EGL_LOSE_CONTEXT_ON_RESET_KHR
+                                : EGL_NO_RESET_NOTIFICATION_KHR);
+            }
+            if (flags != 0) {
+                attributes.put(EGL_CONTEXT_FLAGS_KHR).put(flags);
+            }
+
+            if (data.profile != null) {
+                attributes.put(EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR)
+                        .put(data.profile == GLData.Profile.CORE
+                                ? EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR
+                                : EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR);
+            }
+        } else {
+            if (data.api == GLData.API.GLES && data.majorVersion > 0) {
+                attributes.put(EGL_CONTEXT_CLIENT_VERSION).put(data.majorVersion);
+            }
+            if (data.robustness) {
+                attributes.put(EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT).put(EGL_TRUE);
+                attributes.put(EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT)
+                        .put(data.loseContextOnReset
+                                ? EGL_LOSE_CONTEXT_ON_RESET_EXT
+                                : EGL_NO_RESET_NOTIFICATION_EXT);
+            }
+        }
+
+        if (data.contextReleaseBehavior != null) {
+            attributes.put(EGL_CONTEXT_RELEASE_BEHAVIOR_KHR)
+                    .put(data.contextReleaseBehavior == GLData.ReleaseBehavior.NONE
+                            ? EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR
+                            : EGL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR);
+        }
+        attributes.put(EGL_NONE).flip();
+        return attributes;
+    }
+
+    private long createWindowSurface(long config, long drawable, GLData data) {
+        EGLCapabilities clientCapabilities = EGL.getCapabilities();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            PointerBuffer nativeWindow = stack.pointers(drawable);
+            if (clientCapabilities.EGL15 && clientCapabilities.EGL_KHR_platform_x11) {
+                PointerBuffer attributes = platformSurfaceAttributes(stack, data);
+                return eglCreatePlatformWindowSurface(
+                        eglDisplay, config, memAddress(nativeWindow), attributes);
+            }
+            if (clientCapabilities.EGL_EXT_platform_base
+                    && clientCapabilities.EGL_EXT_platform_x11) {
+                IntBuffer attributes = surfaceAttributes(stack, data);
+                return eglCreatePlatformWindowSurfaceEXT(
+                        eglDisplay, config, memAddress(nativeWindow), attributes);
+            }
+            return eglCreateWindowSurface(eglDisplay, config, drawable, surfaceAttributes(stack, data));
+        }
+    }
+
+    private static IntBuffer surfaceAttributes(MemoryStack stack, GLData data) {
+        IntBuffer attributes = stack.mallocInt(5);
+        if (data.sRGB) {
+            attributes.put(EGL_GL_COLORSPACE_KHR).put(EGL_GL_COLORSPACE_SRGB_KHR);
+        }
+        if (!data.doubleBuffer) {
+            attributes.put(EGL_RENDER_BUFFER).put(EGL_SINGLE_BUFFER);
+        }
+        return attributes.put(EGL_NONE).flip();
+    }
+
+    private static PointerBuffer platformSurfaceAttributes(MemoryStack stack, GLData data) {
+        PointerBuffer attributes = stack.mallocPointer(5);
+        if (data.sRGB) {
+            attributes.put(EGL_GL_COLORSPACE_KHR).put(EGL_GL_COLORSPACE_SRGB_KHR);
+        }
+        if (!data.doubleBuffer) {
+            attributes.put(EGL_RENDER_BUFFER).put(EGL_SINGLE_BUFFER);
+        }
+        return attributes.put(EGL_NONE).flip();
+    }
+
+    private void populateEffectiveConfig(long config, GLData requested, GLData effective)
+            throws AWTException {
+        effective.redSize = getConfigAttribute(config, EGL_RED_SIZE);
+        effective.greenSize = getConfigAttribute(config, EGL_GREEN_SIZE);
+        effective.blueSize = getConfigAttribute(config, EGL_BLUE_SIZE);
+        effective.alphaSize = getConfigAttribute(config, EGL_ALPHA_SIZE);
+        effective.depthSize = getConfigAttribute(config, EGL_DEPTH_SIZE);
+        effective.stencilSize = getConfigAttribute(config, EGL_STENCIL_SIZE);
+        effective.samples = getConfigAttribute(config, EGL_SAMPLES);
+        effective.sampleBuffers = getConfigAttribute(config, EGL_SAMPLE_BUFFERS);
+        effective.pixelFormatFloat = requested.pixelFormatFloat;
+        effective.sRGB = requested.sRGB;
+
+        IntBuffer renderBuffer = BufferUtils.createIntBuffer(1);
+        if (eglQueryContext(eglDisplay, eglContext, EGL_RENDER_BUFFER, renderBuffer)) {
+            effective.doubleBuffer = renderBuffer.get(0) == EGL_BACK_BUFFER;
+        } else {
+            eglGetError();
+            effective.doubleBuffer = requested.doubleBuffer;
+        }
+    }
+
+    private int getConfigAttribute(long config, int attribute) throws AWTException {
+        IntBuffer value = BufferUtils.createIntBuffer(1);
+        if (!eglGetConfigAttrib(eglDisplay, config, attribute, value)) {
+            throw eglFailure("Failed to query EGL framebuffer configuration");
+        }
+        return value.get(0);
+    }
+
+    private static void populateEffectiveGLAttributes(GLData requested, GLData effective)
+            throws AWTException {
+        long glGetIntegerv = GL.getFunctionProvider().getFunctionAddress("glGetIntegerv");
+        long glGetString = GL.getFunctionProvider().getFunctionAddress("glGetString");
+        APIVersion version = APIUtil.apiParseVersion(getString(GL11.GL_VERSION, glGetString));
+
+        effective.api = requested.api;
+        effective.majorVersion = version.major;
+        effective.minorVersion = version.minor;
+
+        if (requested.api == GLData.API.GL && GLUtil.atLeast32(version.major, version.minor)) {
+            int profileFlags = getInteger(GL32.GL_CONTEXT_PROFILE_MASK, glGetIntegerv);
+            if ((profileFlags & GL32.GL_CONTEXT_CORE_PROFILE_BIT) != 0) {
+                effective.profile = GLData.Profile.CORE;
+            } else if ((profileFlags & GL32.GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) != 0) {
+                effective.profile = GLData.Profile.COMPATIBILITY;
+            } else if (profileFlags != 0) {
+                throw new AWTException("Unknown OpenGL profile " + profileFlags);
+            }
+        }
+
+        if (requested.api == GLData.API.GL && version.major >= 3) {
+            int contextFlags = getInteger(GL30.GL_CONTEXT_FLAGS, glGetIntegerv);
+            effective.debug = (contextFlags & GL43.GL_CONTEXT_FLAG_DEBUG_BIT) != 0;
+            effective.forwardCompatible =
+                    (contextFlags & GL30.GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT) != 0;
+            effective.robustness =
+                    (contextFlags & ARBRobustness.GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB) != 0;
+        }
+        if (effective.robustness) {
+            int notificationStrategy = getInteger(
+                    ARBRobustness.GL_RESET_NOTIFICATION_STRATEGY_ARB, glGetIntegerv);
+            effective.loseContextOnReset =
+                    notificationStrategy == ARBRobustness.GL_LOSE_CONTEXT_ON_RESET_ARB;
+        }
+        effective.samples = getInteger(GL13.GL_SAMPLES, glGetIntegerv);
+        effective.sampleBuffers = effective.samples > 0 ? 1 : 0;
+        effective.contextReleaseBehavior = requested.contextReleaseBehavior;
+    }
+
+    private static int getInteger(int name, long function) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer value = stack.callocInt(1);
+            JNI.callPV(name, memAddress(value), function);
+            return value.get(0);
+        }
+    }
+
+    private static String getString(int name, long function) {
+        return memUTF8(Checks.check(JNI.callP(name, function)));
+    }
+
+    @Override
+    public void lock() throws AWTException {
+        JAWTDrawingSurface drawingSurface = JAWT_GetDrawingSurface(canvas, AWT.GetDrawingSurface());
+        if (drawingSurface == null) {
+            throw new AWTException("Failed to get JAWT drawing surface");
+        }
+        int lock = JAWT_DrawingSurface_Lock(drawingSurface, drawingSurface.Lock());
+        if ((lock & JAWT_LOCK_ERROR) != 0) {
+            JAWT_FreeDrawingSurface(drawingSurface, AWT.FreeDrawingSurface());
+            throw new AWTException("JAWT_DrawingSurface_Lock() failed");
+        }
+        ds = drawingSurface;
+    }
+
+    @Override
+    public void unlock() throws AWTException {
+        JAWTDrawingSurface drawingSurface = ds;
+        if (drawingSurface == null) {
+            throw new AWTException("JAWT drawing surface is not locked");
+        }
+        try {
+            JAWT_DrawingSurface_Unlock(drawingSurface, drawingSurface.Unlock());
+        } finally {
+            JAWT_FreeDrawingSurface(drawingSurface, AWT.FreeDrawingSurface());
+            ds = null;
+        }
+    }
+
+    @Override
+    public boolean makeCurrent(long context) {
+        if (eglDisplay == EGL_NO_DISPLAY) {
+            return context == EGL_NO_CONTEXT;
+        }
+        if (context == EGL_NO_CONTEXT) {
+            return eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        }
+        return eglMakeCurrent(eglDisplay, eglSurface, eglSurface, context);
+    }
+
+    @Override
+    public boolean isCurrent(long context) {
+        return eglGetCurrentContext() == context;
+    }
+
+    @Override
+    public boolean swapBuffers() {
+        return eglSwapBuffers(eglDisplay, eglSurface);
+    }
+
+    @Override
+    public boolean delayBeforeSwapNV(float seconds) {
+        throw new UnsupportedOperationException("NYI");
+    }
+
+    @Override
+    public boolean getFramebufferSize(int[] size) {
+        if (eglDisplay == EGL_NO_DISPLAY || eglSurface == EGL_NO_SURFACE) {
+            return false;
+        }
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer width = stack.mallocInt(1);
+            IntBuffer height = stack.mallocInt(1);
+            if (!eglQuerySurface(eglDisplay, eglSurface, EGL_WIDTH, width)
+                    || !eglQuerySurface(eglDisplay, eglSurface, EGL_HEIGHT, height)) {
+                eglGetError();
+                return false;
+            }
+            size[0] = width.get(0);
+            size[1] = height.get(0);
+            return true;
+        }
+    }
+
+    @Override
+    public boolean deleteContext(long context) {
+        boolean success = true;
+        if (eglDisplay != EGL_NO_DISPLAY) {
+            if (eglGetCurrentContext() == context) {
+                success &= eglMakeCurrent(
+                        eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+            }
+            if (eglSurface != EGL_NO_SURFACE) {
+                success &= eglDestroySurface(eglDisplay, eglSurface);
+            }
+            if (context != EGL_NO_CONTEXT) {
+                success &= eglDestroyContext(eglDisplay, context);
+            }
+        }
+        eglSurface = EGL_NO_SURFACE;
+        eglContext = EGL_NO_CONTEXT;
+        releaseDisplay();
+        return success;
+    }
+
+    private void cleanupAfterFailedCreate() {
+        if (eglDisplay != EGL_NO_DISPLAY) {
+            eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+            if (eglSurface != EGL_NO_SURFACE) {
+                eglDestroySurface(eglDisplay, eglSurface);
+            }
+            if (eglContext != EGL_NO_CONTEXT) {
+                eglDestroyContext(eglDisplay, eglContext);
+            }
+        }
+        eglSurface = EGL_NO_SURFACE;
+        eglContext = EGL_NO_CONTEXT;
+        releaseDisplay();
+    }
+
+    private void releaseDisplay() {
+        DisplayRef ref = displayRef;
+        displayRef = null;
+        eglDisplay = EGL_NO_DISPLAY;
+        if (ref != null) {
+            releaseDisplay(ref);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        canvas = null;
+    }
+
+    private static synchronized DisplayRef acquireDisplay(long nativeDisplay, int screen)
+            throws AWTException {
+        long eglDisplay = createDisplay(nativeDisplay, screen);
+        if (eglDisplay == EGL_NO_DISPLAY) {
+            throw eglFailure("Failed to obtain EGL display for the AWT X11 display");
+        }
+
+        DisplayRef existing = DISPLAY_REFS.get(eglDisplay);
+        if (existing != null) {
+            existing.references++;
+            return existing;
+        }
+
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer major = stack.mallocInt(1);
+            IntBuffer minor = stack.mallocInt(1);
+            if (!eglInitialize(eglDisplay, major, minor)) {
+                throw eglFailure("Failed to initialize EGL display");
+            }
+            EGLCapabilities capabilities = EGL.createDisplayCapabilities(
+                    eglDisplay, major.get(0), minor.get(0));
+            DisplayRef created = new DisplayRef(eglDisplay, capabilities);
+            DISPLAY_REFS.put(eglDisplay, created);
+            return created;
+        } catch (AWTException | RuntimeException | Error failure) {
+            eglTerminate(eglDisplay);
+            throw failure;
+        }
+    }
+
+    private static long createDisplay(long nativeDisplay, int screen) {
+        EGLCapabilities capabilities = EGL.getCapabilities();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            if (capabilities.EGL15 && capabilities.EGL_KHR_platform_x11) {
+                PointerBuffer attributes = stack.pointers(
+                        EGL_PLATFORM_X11_SCREEN_KHR, screen, EGL_NONE);
+                return eglGetPlatformDisplay(
+                        EGL_PLATFORM_X11_KHR, nativeDisplay, attributes);
+            }
+            if (capabilities.EGL_EXT_platform_base && capabilities.EGL_EXT_platform_x11) {
+                IntBuffer attributes = stack.ints(
+                        EGL_PLATFORM_X11_SCREEN_EXT, screen, EGL_NONE);
+                return eglGetPlatformDisplayEXT(
+                        EGL_PLATFORM_X11_EXT, nativeDisplay, attributes);
+            }
+            return eglGetDisplay(nativeDisplay);
+        }
+    }
+
+    private static synchronized void releaseDisplay(DisplayRef ref) {
+        if (--ref.references == 0) {
+            DISPLAY_REFS.remove(ref.eglDisplay);
+            eglTerminate(ref.eglDisplay);
+        }
+    }
+
+    private static AWTException eglFailure(String message) {
+        int error = eglGetError();
+        return new AWTException(message + ": " + eglErrorName(error)
+                + " (0x" + Integer.toHexString(error).toUpperCase() + ")");
+    }
+
+    private static String eglErrorName(int error) {
+        switch (error) {
+        case EGL_SUCCESS:
+            return "EGL_SUCCESS";
+        case EGL_NOT_INITIALIZED:
+            return "EGL_NOT_INITIALIZED";
+        case EGL_BAD_ACCESS:
+            return "EGL_BAD_ACCESS";
+        case EGL_BAD_ALLOC:
+            return "EGL_BAD_ALLOC";
+        case EGL_BAD_ATTRIBUTE:
+            return "EGL_BAD_ATTRIBUTE";
+        case EGL_BAD_CONTEXT:
+            return "EGL_BAD_CONTEXT";
+        case EGL_BAD_CONFIG:
+            return "EGL_BAD_CONFIG";
+        case EGL_BAD_CURRENT_SURFACE:
+            return "EGL_BAD_CURRENT_SURFACE";
+        case EGL_BAD_DISPLAY:
+            return "EGL_BAD_DISPLAY";
+        case EGL_BAD_SURFACE:
+            return "EGL_BAD_SURFACE";
+        case EGL_BAD_MATCH:
+            return "EGL_BAD_MATCH";
+        case EGL_BAD_PARAMETER:
+            return "EGL_BAD_PARAMETER";
+        case EGL_BAD_NATIVE_PIXMAP:
+            return "EGL_BAD_NATIVE_PIXMAP";
+        case EGL_BAD_NATIVE_WINDOW:
+            return "EGL_BAD_NATIVE_WINDOW";
+        default:
+            return "unknown EGL error";
+        }
+    }
+
+    private static final class DisplayRef {
+        private final long eglDisplay;
+        private final EGLCapabilities capabilities;
+        private int references = 1;
+
+        private DisplayRef(long eglDisplay, EGLCapabilities capabilities) {
+            this.eglDisplay = eglDisplay;
+            this.capabilities = capabilities;
+        }
+    }
+}

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
@@ -341,7 +341,9 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
         if (!data.doubleBuffer) {
             attributes.put(EGL_RENDER_BUFFER).put(EGL_SINGLE_BUFFER);
         }
-        return attributes.put(EGL_NONE).flip();
+        attributes.put(EGL_NONE);
+        attributes.flip();
+        return attributes;
     }
 
     private static PointerBuffer platformSurfaceAttributes(MemoryStack stack, GLData data) {

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvasFactory.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvasFactory.java
@@ -1,0 +1,22 @@
+package org.lwjgl.opengl.awt;
+
+import org.lwjgl.system.Configuration;
+
+final class PlatformLinuxGLCanvasFactory {
+    private PlatformLinuxGLCanvasFactory() {
+    }
+
+    static PlatformGLCanvas create() {
+        return shouldUseEGL(
+                Configuration.OPENGL_CONTEXT_API.get(),
+                System.getenv("XDG_SESSION_TYPE"),
+                System.getenv("WAYLAND_DISPLAY"))
+                ? new PlatformLinuxEGLCanvas()
+                : new PlatformLinuxGLCanvas();
+    }
+
+    static boolean shouldUseEGL(String contextAPI, String sessionType, String waylandDisplay) {
+        return "EGL".equals(contextAPI)
+                || contextAPI == null && "wayland".equals(sessionType) && waylandDisplay != null;
+    }
+}

--- a/test/org/lwjgl/opengl/awt/LinuxEGLCanvasIntegrationTest.java
+++ b/test/org/lwjgl/opengl/awt/LinuxEGLCanvasIntegrationTest.java
@@ -1,0 +1,164 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.system.Configuration;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import java.awt.Dimension;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.lwjgl.egl.EGL10.EGL_NO_CONTEXT;
+import static org.lwjgl.egl.EGL14.eglGetCurrentContext;
+
+@EnabledOnOs(OS.LINUX)
+class LinuxEGLCanvasIntegrationTest {
+    @Test
+    void rendersWithAnEGLContextWhenEGLIsSelected() throws Exception {
+        assumeEGLIsSelected();
+
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+        AtomicReference<TestCanvas> canvasRef = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() ->
+                createFrame("Linux EGL integration test", frameRef, canvasRef));
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = canvasRef.get();
+                canvas.render();
+                assertTrue(canvas.platformCanvas instanceof PlatformLinuxEGLCanvas);
+                assertTrue(canvas.getFramebufferWidth() > 0);
+                assertTrue(canvas.getFramebufferHeight() > 0);
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                GL.setCapabilities(null);
+                dispose(frameRef.get());
+            });
+        }
+    }
+
+    @Test
+    void keepsTheDisplayAliveWhileAnotherCanvasUsesIt() throws Exception {
+        assumeEGLIsSelected();
+
+        AtomicReference<JFrame> firstFrameRef = new AtomicReference<>();
+        AtomicReference<JFrame> secondFrameRef = new AtomicReference<>();
+        AtomicReference<TestCanvas> firstCanvasRef = new AtomicReference<>();
+        AtomicReference<TestCanvas> secondCanvasRef = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            createFrame("First Linux EGL canvas", firstFrameRef, firstCanvasRef);
+            createFrame("Second Linux EGL canvas", secondFrameRef, secondCanvasRef);
+        });
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                firstCanvasRef.get().render();
+                secondCanvasRef.get().render();
+
+                firstFrameRef.get().dispose();
+                secondCanvasRef.get().render();
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                GL.setCapabilities(null);
+                dispose(firstFrameRef.get());
+                dispose(secondFrameRef.get());
+            });
+        }
+    }
+
+    @Test
+    void honorsCoreProfileContextAttributes() throws Exception {
+        assumeEGLIsSelected();
+
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 2;
+        data.profile = GLData.Profile.CORE;
+        data.swapInterval = 0;
+
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+        AtomicReference<TestCanvas> canvasRef = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> createFrame(
+                "Linux EGL core profile test", new TestCanvas(data), frameRef, canvasRef));
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = canvasRef.get();
+                canvas.render();
+                assertEquals(GLData.API.GL, canvas.effective.api);
+                assertTrue(GLUtil.atLeast32(
+                        canvas.effective.majorVersion, canvas.effective.minorVersion));
+                assertEquals(GLData.Profile.CORE, canvas.effective.profile);
+                assertEquals(Integer.valueOf(0), canvas.effective.swapInterval);
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                GL.setCapabilities(null);
+                dispose(frameRef.get());
+            });
+        }
+    }
+
+    private static void assumeEGLIsSelected() {
+        assumeTrue(PlatformLinuxGLCanvasFactory.shouldUseEGL(
+                        Configuration.OPENGL_CONTEXT_API.get(),
+                        System.getenv("XDG_SESSION_TYPE"),
+                        System.getenv("WAYLAND_DISPLAY")),
+                "EGL is not selected");
+    }
+
+    private static void createFrame(String title, AtomicReference<JFrame> frameRef,
+            AtomicReference<TestCanvas> canvasRef) {
+        createFrame(title, new TestCanvas(), frameRef, canvasRef);
+    }
+
+    private static void createFrame(String title, TestCanvas canvas,
+            AtomicReference<JFrame> frameRef, AtomicReference<TestCanvas> canvasRef) {
+        canvas.setPreferredSize(new Dimension(320, 240));
+
+        JFrame frame = new JFrame(title);
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        frame.getContentPane().add(canvas);
+        frame.pack();
+        frame.setVisible(true);
+        frameRef.set(frame);
+        canvasRef.set(canvas);
+    }
+
+    private static void dispose(JFrame frame) {
+        if (frame != null) {
+            frame.dispose();
+        }
+    }
+
+    private static final class TestCanvas extends AWTGLCanvas {
+        private static final long serialVersionUID = 1L;
+
+        private TestCanvas() {
+        }
+
+        private TestCanvas(GLData data) {
+            super(data);
+        }
+
+        @Override
+        public void initGL() {
+            GL.createCapabilities();
+        }
+
+        @Override
+        public void paintGL() {
+            assertTrue(context != EGL_NO_CONTEXT);
+            assertEquals(context, eglGetCurrentContext());
+            swapBuffers();
+        }
+    }
+}

--- a/test/org/lwjgl/opengl/awt/PlatformLinuxGLCanvasFactoryTest.java
+++ b/test/org/lwjgl/opengl/awt/PlatformLinuxGLCanvasFactoryTest.java
@@ -1,0 +1,21 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlatformLinuxGLCanvasFactoryTest {
+    @Test
+    void followsExplicitContextAPI() {
+        assertTrue(PlatformLinuxGLCanvasFactory.shouldUseEGL("EGL", "x11", null));
+        assertFalse(PlatformLinuxGLCanvasFactory.shouldUseEGL("native", "wayland", "wayland-0"));
+    }
+
+    @Test
+    void defaultsToEGLInWaylandSessions() {
+        assertTrue(PlatformLinuxGLCanvasFactory.shouldUseEGL(null, "wayland", "wayland-0"));
+        assertFalse(PlatformLinuxGLCanvasFactory.shouldUseEGL(null, "wayland", null));
+        assertFalse(PlatformLinuxGLCanvasFactory.shouldUseEGL(null, "x11", "wayland-0"));
+    }
+}


### PR DESCRIPTION
Recent LWJGL versions select EGL by default in Wayland sessions, while `AWTGLCanvas` always attempted to create a GLX context. This adds a Linux EGL backend for the X11 window exposed by AWT under XWayland. Backend selection now follows `Configuration.OPENGL_CONTEXT_API`: explicit EGL and default Wayland sessions use EGL, while `native` continues to use GLX.

This follows the same basic direction as #85, with @JNightRider credited as co-author for that earlier work. The implementation has been rewritten for the current codebase. It follows LWJGL’s process-wide backend selection instead of adding a separate per-canvas option, matches EGL configurations to the AWT window visual, supports the EGL X11 platform APIs with a legacy fallback, handles shared display ownership and partial-failure cleanup, and follows the current JAWT drawing-surface lifecycle. It also validates unsupported `GLData` options instead of silently ignoring them.

The change was tested on a real Wayland/XWayland desktop and with Mesa/llvmpipe under Xvfb. Default and OpenGL 3.2 core contexts, multiple canvases, teardown and recreation, framebuffer sizing, and screenshot rendering all pass. The existing GLX test suite remains green, and Linux CI now runs both GLX and EGL coverage.

This is not native Wayland support: AWT still supplies an X11 window through XWayland.

Fixes #84.