### PR TITLE
Enforce JDK 8 API compatibility for modern JDK builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,13 @@
 		</developer>
 	</developers>
 	<properties>
+		<animal-sniffer-maven-plugin.version>1.27</animal-sniffer-maven-plugin.version>
 		<lwjgl.version>3.4.2</lwjgl.version>
 		<junit.version>5.11.4</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.release>8</maven.compiler.release>
+		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
 		<maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
 		<maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
@@ -254,6 +255,32 @@
 				<configuration>
 					<publishingServerId>central</publishingServerId>
 					<autoPublish>true</autoPublish>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>${animal-sniffer-maven-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>check-java-8-api</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<signature>
+						<groupId>org.codehaus.mojo.signature</groupId>
+						<artifactId>java18</artifactId>
+						<version>1.0</version>
+					</signature>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Although the project targets Java 8, using only `source` and `target` allowed builds made with newer JDKs to reference newer Java APIs. This caused the `NoSuchMethodError` reported in #62.

This PR switches compilation to `release=8`, adds an API compatibility check for all generated platform classes. It complements #135: its modern-JDK jobs exercise the application, while this PR ensures those builds only reference Java 8 APIs. Together they prevent the cross-compilation problem reported in #62.

Fixes #62.