### PR TITLE
Isolate Vulkan from AWT X11 connections

### DIFF
--- a/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/PlatformX11VKCanvas.java
@@ -1,15 +1,21 @@
 package org.lwjgl.vulkan.awt;
 
 import org.lwjgl.awt.AWT;
+import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.jawt.JAWTX11DrawingSurfaceInfo;
+import org.lwjgl.system.linux.X11;
 import org.lwjgl.vulkan.VkInstance;
 import org.lwjgl.vulkan.VkPhysicalDevice;
 import org.lwjgl.vulkan.VkXlibSurfaceCreateInfoKHR;
 
 import java.awt.*;
 import java.nio.LongBuffer;
+import java.util.HashMap;
+import java.util.Map;
 
+import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.system.MemoryUtil.memUTF8;
 import static org.lwjgl.vulkan.KHRXlibSurface.*;
 import static org.lwjgl.vulkan.VK10.*;
 
@@ -22,6 +28,13 @@ import static org.lwjgl.vulkan.VK10.*;
 public class PlatformX11VKCanvas implements PlatformVKCanvas {
 
     public static final String EXTENSION_NAME = VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
+
+    private static final Object DISPLAY_LOCK = new Object();
+    private static final Map<String, Long> VULKAN_DISPLAYS = new HashMap<>();
+    private static final Map<Long, Long> VULKAN_DISPLAY_VISUALS = new HashMap<>();
+    private static final long X_DISPLAY_STRING = getRequiredX11Function("XDisplayString");
+    private static final long X_DEFAULT_VISUAL = getRequiredX11Function("XDefaultVisual");
+    private static final long X_VISUAL_ID_FROM_VISUAL = getRequiredX11Function("XVisualIDFromVisual");
 
     /**
      * @deprecated Please migrate to the {@link AWTVK} API.
@@ -44,15 +57,19 @@ public class PlatformX11VKCanvas implements PlatformVKCanvas {
         try (AWT awt = new AWT(canvas)) {
             try (MemoryStack stack = MemoryStack.stackPush()) {
                 JAWTX11DrawingSurfaceInfo dsiX11 = JAWTX11DrawingSurfaceInfo.create(awt.getPlatformInfo());
+                long display = getVulkanDisplay(dsiX11.display());
 
                 VkXlibSurfaceCreateInfoKHR pCreateInfo = VkXlibSurfaceCreateInfoKHR
                         .calloc(stack)
                         .sType(VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR)
-                        .dpy(dsiX11.display())
+                        .dpy(display)
                         .window(dsiX11.drawable());
 
                 LongBuffer pSurface = stack.mallocLong(1);
-                int result = vkCreateXlibSurfaceKHR(instance, pCreateInfo, null, pSurface);
+                int result;
+                synchronized (DISPLAY_LOCK) {
+                    result = vkCreateXlibSurfaceKHR(instance, pCreateInfo, null, pSurface);
+                }
 
                 switch (result) {
                     case VK_SUCCESS:
@@ -87,6 +104,105 @@ public class PlatformX11VKCanvas implements PlatformVKCanvas {
     }
 
     static boolean checkSupport(VkPhysicalDevice physicalDevice, int queueFamilyIndex) {
-        return vkGetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, 0, 0);
+        try {
+            synchronized (DISPLAY_LOCK) {
+                long display = getDefaultVulkanDisplay();
+                return vkGetPhysicalDeviceXlibPresentationSupportKHR(
+                        physicalDevice, queueFamilyIndex, display, getDefaultVisualID(display));
+            }
+        } catch (AWTException e) {
+            return false;
+        }
+    }
+
+    static long getVulkanDisplay(long awtDisplay) throws AWTException {
+        if (awtDisplay == NULL) {
+            throw new AWTException("JAWT returned no X11 display");
+        }
+        return getVulkanDisplay(getDisplayName(awtDisplay));
+    }
+
+    static long getDefaultVisualID(long display) throws AWTException {
+        synchronized (DISPLAY_LOCK) {
+            Long visualID = VULKAN_DISPLAY_VISUALS.get(display);
+            if (visualID == null) {
+                throw new AWTException("Unknown Vulkan X11 display connection");
+            }
+            return visualID;
+        }
+    }
+
+    private static long queryDefaultVisualID(long display) throws AWTException {
+        int screen = X11.XDefaultScreen(display);
+        long visual = JNI.callPP(display, screen, X_DEFAULT_VISUAL);
+        if (visual == NULL) {
+            throw new AWTException("X11 returned no default visual for screen " + screen);
+        }
+        long visualID = JNI.callPP(visual, X_VISUAL_ID_FROM_VISUAL);
+        if (visualID == 0L) {
+            throw new AWTException("X11 returned an invalid default visual ID for screen " + screen);
+        }
+        return visualID;
+    }
+
+    private static long getDefaultVulkanDisplay() throws AWTException {
+        return getVulkanDisplay(System.getenv("DISPLAY"));
+    }
+
+    private static long getVulkanDisplay(String displayName) throws AWTException {
+        synchronized (DISPLAY_LOCK) {
+            Long display = VULKAN_DISPLAYS.get(displayName);
+            return display == null ? openVulkanDisplay(displayName) : display;
+        }
+    }
+
+    private static long openVulkanDisplay(String displayName) throws AWTException {
+        synchronized (DISPLAY_LOCK) {
+            long display = displayName == null
+                    ? X11.nXOpenDisplay(NULL)
+                    : X11.XOpenDisplay(displayName);
+            if (display == NULL) {
+                throw new AWTException("Failed to open a dedicated X11 display connection for Vulkan"
+                        + (displayName == null ? "" : ": " + displayName));
+            }
+
+            String canonicalName;
+            long defaultVisualID;
+            try {
+                canonicalName = getDisplayName(display);
+                defaultVisualID = queryDefaultVisualID(display);
+            } catch (AWTException | RuntimeException | Error failure) {
+                X11.XCloseDisplay(display);
+                throw failure;
+            }
+            Long existing = VULKAN_DISPLAYS.get(canonicalName);
+            if (existing != null) {
+                X11.XCloseDisplay(display);
+                display = existing;
+            } else {
+                // VkSurfaceKHR retains the Display pointer, while AWTVK exposes only the raw surface handle.
+                // Keep one isolated connection per X server alive for the lifetime of the process.
+                VULKAN_DISPLAYS.put(canonicalName, display);
+                VULKAN_DISPLAY_VISUALS.put(display, defaultVisualID);
+            }
+            VULKAN_DISPLAYS.put(displayName, display);
+            return display;
+        }
+    }
+
+    private static String getDisplayName(long display) throws AWTException {
+        long name = JNI.callPP(display, X_DISPLAY_STRING);
+        if (name == NULL) {
+            throw new AWTException("X11 returned no display name");
+        }
+        return memUTF8(name);
+    }
+
+    private static long getRequiredX11Function(String name) {
+        long address = X11.getLibrary().getFunctionAddress(name);
+        if (address == NULL) {
+            throw new AssertionError("Failed to resolve X11 function " + name);
+        }
+        return address;
     }
 }

--- a/test/org/lwjgl/vulkan/awt/PlatformX11VKCanvasDisplayTest.java
+++ b/test/org/lwjgl/vulkan/awt/PlatformX11VKCanvasDisplayTest.java
@@ -1,0 +1,63 @@
+package org.lwjgl.vulkan.awt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.lwjgl.awt.AWT;
+import org.lwjgl.system.jawt.JAWTX11DrawingSurfaceInfo;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import java.awt.Canvas;
+import java.awt.Dimension;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs(OS.LINUX)
+class PlatformX11VKCanvasDisplayTest {
+    @Test
+    void usesDedicatedReusableDisplayForTheAWTServer() throws Exception {
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+        AtomicReference<Canvas> canvasRef = new AtomicReference<>();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                Canvas canvas = new Canvas();
+                canvas.setPreferredSize(new Dimension(320, 240));
+
+                JFrame frame = new JFrame("Vulkan X11 display isolation test");
+                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                frame.add(canvas);
+                frame.pack();
+                frame.setVisible(true);
+                frameRef.set(frame);
+                canvasRef.set(canvas);
+            });
+
+            try (AWT awt = new AWT(canvasRef.get())) {
+                long awtDisplay = JAWTX11DrawingSurfaceInfo
+                        .create(awt.getPlatformInfo())
+                        .display();
+                long vulkanDisplay = PlatformX11VKCanvas.getVulkanDisplay(awtDisplay);
+
+                assertNotEquals(0L, awtDisplay);
+                assertNotEquals(0L, vulkanDisplay);
+                assertNotEquals(awtDisplay, vulkanDisplay,
+                        "Vulkan must not share AWT's X11 connection");
+                assertEquals(vulkanDisplay, PlatformX11VKCanvas.getVulkanDisplay(awtDisplay),
+                        "Canvases on the same X server should reuse the isolated connection");
+                assertTrue(PlatformX11VKCanvas.getDefaultVisualID(vulkanDisplay) > 0L,
+                        "The isolated connection must expose a valid default visual");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                JFrame frame = frameRef.get();
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
On Linux, Vulkan surfaces were created using the X11 display connection owned by AWT. AWT and Vulkan could then access the same connection without coordinating their locking, causing nondeterministic Xlib/XCB queue corruption and subsequent surface or swapchain failures in `ClearScreenDemo`.

This change opens and reuses a dedicated process-lifetime X11 connection for Vulkan surfaces. The AWT drawable remains the native window, but Vulkan no longer shares AWT’s connection. `AWTVK.checkSupport` now also uses a valid display and visual instead of null handles.

A Linux test verifies that the Vulkan connection is separate from AWT’s connection, reused for the same X server, and provides a valid visual. The clean non-screen-capture suite passes with 44 tests, and two separate 12-run `ClearScreenDemo` stress tests completed without reproducing the failure.

Calling `XInitThreads` after AWT initialization would not be reliable because it must be called before any other Xlib function. This implementation therefore avoids sharing the connection entirely. The relevant Xlib threading requirements are documented at https://www.x.org/releases/X11R7.6/doc/libX11/specs/libX11/libX11.html.

Fixes #59.