### PR TITLE
Add a context-current disposal callback to `AWTGLCanvas`

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -60,8 +60,21 @@ public abstract class AWTGLCanvas extends Canvas {
     public void removeNotify() {
         lifecycleLock.lock();
         try {
-            super.removeNotify();
-            disposeCanvas();
+            Throwable failure = null;
+            try {
+                // disposeGL() needs the native peer in order to make the context current.
+                disposeCanvas();
+            } catch (RuntimeException | Error e) {
+                failure = e;
+            }
+            try {
+                super.removeNotify();
+            } catch (RuntimeException | Error e) {
+                failure = appendFailure(failure, e);
+            }
+            if (failure != null) {
+                rethrow(failure);
+            }
         } finally {
             lifecycleLock.unlock();
         }
@@ -73,28 +86,59 @@ public abstract class AWTGLCanvas extends Canvas {
     }
 
     /**
-     * Deletes the OpenGL context and releases platform-specific canvas resources.
+     * Invokes {@link #disposeGL()}, deletes the OpenGL context, and releases platform-specific canvas resources.
      *
      * <p>If rendering is in progress on another thread, this method waits for that operation to finish before deleting
-     * the context. Applications remain responsible for stopping any render loop before disposing the canvas.</p>
+     * the context. Applications remain responsible for stopping any render loop before disposing the canvas. The
+     * callback runs on the thread that calls this method, which may differ from the rendering thread. If the callback
+     * fails, context deletion and platform cleanup are still attempted before the failure is rethrown.</p>
      */
     public void disposeCanvas() {
         lifecycleLock.lock();
         try {
-            try {
-                if (context != 0L) {
-                    platformCanvas.deleteContext(context);
+            Throwable failure = null;
+            long contextToDelete = context;
+            if (contextToDelete != 0L) {
+                try {
+                    disposeGLInContext();
+                } catch (RuntimeException | Error e) {
+                    failure = e;
                 }
-            } finally {
-                // prepare for a possible re-adding
-                context = 0L;
-                initCalled = false;
+                try {
+                    platformCanvas.deleteContext(contextToDelete);
+                } catch (RuntimeException | Error e) {
+                    failure = appendFailure(failure, e);
+                }
+            }
+            // prepare for a possible re-adding
+            context = 0L;
+            initCalled = false;
+            try {
                 platformCanvas.dispose();
+            } catch (RuntimeException | Error e) {
+                failure = appendFailure(failure, e);
+            }
+            if (failure != null) {
+                rethrow(failure);
             }
         } finally {
             lifecycleLock.unlock();
         }
     }
+
+    private void disposeGLInContext() {
+        lockAndMakeCurrent(false);
+        Throwable callbackFailure = null;
+        try {
+            disposeGL();
+        } catch (RuntimeException | Error failure) {
+            callbackFailure = failure;
+            throw failure;
+        } finally {
+            afterDisposeGL(callbackFailure);
+        }
+    }
+
     protected AWTGLCanvas(GLData data) {
         this.data = data;
         this.addComponentListener(listener);
@@ -113,6 +157,10 @@ public abstract class AWTGLCanvas extends Canvas {
                 throw new RuntimeException("Exception while creating the OpenGL context", e);
             }
         }
+        lockAndMakeCurrent(true);
+    }
+
+    private void lockAndMakeCurrent(boolean updateFramebuffer) {
         try {
             platformCanvas.lock(); // <- MUST lock on Linux
         } catch (AWTException e) {
@@ -122,7 +170,9 @@ public abstract class AWTGLCanvas extends Canvas {
             if (!platformCanvas.makeCurrent(context)) {
                 throw new IllegalStateException("Failed to make the OpenGL context current");
             }
-            updateFramebufferSize();
+            if (updateFramebuffer) {
+                updateFramebufferSize();
+            }
         } catch (RuntimeException | Error failure) {
             releaseDrawingSurfaceAfterFailure(failure);
             throw failure;
@@ -130,6 +180,10 @@ public abstract class AWTGLCanvas extends Canvas {
     }
 
     protected void afterRender() {
+        clearCurrentAndUnlock();
+    }
+
+    private void clearCurrentAndUnlock() {
         Throwable failure = null;
         try {
             if (!platformCanvas.makeCurrent(0L)) {
@@ -181,6 +235,16 @@ public abstract class AWTGLCanvas extends Canvas {
             throw (Error) failure;
         }
         throw (RuntimeException) failure;
+    }
+
+    private static Throwable appendFailure(Throwable failure, Throwable additionalFailure) {
+        if (failure == null) {
+            return additionalFailure;
+        }
+        if (failure != additionalFailure) {
+            failure.addSuppressed(additionalFailure);
+        }
+        return failure;
     }
 
     public <T> T executeInContext(Callable<T> callable) throws Exception {
@@ -253,12 +317,23 @@ public abstract class AWTGLCanvas extends Canvas {
         try {
             afterRender();
         } catch (RuntimeException | Error cleanupFailure) {
-            if (callbackFailure == null) {
-                throw cleanupFailure;
-            }
-            if (callbackFailure != cleanupFailure) {
-                callbackFailure.addSuppressed(cleanupFailure);
-            }
+            handleCleanupFailure(callbackFailure, cleanupFailure);
+        }
+    }
+
+    private void afterDisposeGL(Throwable callbackFailure) {
+        try {
+            clearCurrentAndUnlock();
+        } catch (RuntimeException | Error cleanupFailure) {
+            handleCleanupFailure(callbackFailure, cleanupFailure);
+        }
+    }
+
+    private static void handleCleanupFailure(Throwable callbackFailure, Throwable cleanupFailure) {
+        if (callbackFailure == null) {
+            rethrow(cleanupFailure);
+        } else if (callbackFailure != cleanupFailure) {
+            callbackFailure.addSuppressed(cleanupFailure);
         }
     }
 
@@ -271,6 +346,23 @@ public abstract class AWTGLCanvas extends Canvas {
      * Will be called whenever the {@link Canvas} needs to paint itself.
      */
     public abstract void paintGL();
+
+    /**
+     * Will be called before this canvas's OpenGL context is deleted.
+     *
+     * <p>The drawing surface is locked and the context is current while this callback runs. It is invoked at most once
+     * for each created context, including a context for which {@link #initGL()} did not complete. It is not invoked when
+     * there is no context or when the context cannot be made current.</p>
+     *
+     * <p>This callback runs on the thread that disposes the canvas, which is normally the AWT event-dispatch thread for
+     * automatic removal and may differ from the rendering thread. LWJGL's OpenGL and OpenGL ES capabilities are
+     * thread-local; applications rendering on another thread must install the corresponding capabilities before issuing
+     * GL calls here and clear or restore them before returning.</p>
+     *
+     * <p>This callback must not make the context non-current or invoke this canvas's rendering or disposal methods.</p>
+     */
+    protected void disposeGL() {
+    }
 
     public int getFramebufferWidth() {
         return framebufferWidth;

--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -42,6 +42,8 @@ public abstract class AWTGLCanvas extends Canvas {
     protected final GLData effective = new GLData();
     protected boolean initCalled;
     private final ReentrantLock lifecycleLock = new ReentrantLock();
+    /** Whether context teardown is in progress while {@link #lifecycleLock} is held. */
+    private boolean disposing;
     private volatile int framebufferWidth;
     private volatile int framebufferHeight;
     private final ComponentListener listener = new ComponentAdapter() {
@@ -91,43 +93,52 @@ public abstract class AWTGLCanvas extends Canvas {
      * <p>If rendering is in progress on another thread, this method waits for that operation to finish before deleting
      * the context. Applications remain responsible for stopping any render loop before disposing the canvas. The
      * callback runs on the thread that calls this method, which may differ from the rendering thread. If the callback
-     * fails, context deletion and platform cleanup are still attempted before the failure is rethrown.</p>
+     * fails, context deletion and platform cleanup are still attempted before the failure is rethrown. A reentrant call
+     * from {@link #disposeGL()} returns without doing anything.</p>
      */
     public void disposeCanvas() {
         lifecycleLock.lock();
         try {
-            Throwable failure = null;
-            long contextToDelete = context;
-            if (contextToDelete != 0L) {
-                try {
-                    disposeGLInContext();
-                } catch (RuntimeException | Error e) {
-                    failure = e;
+            if (disposing) {
+                return;
+            }
+            disposing = true;
+            try {
+                Throwable failure = null;
+                long contextToDelete = context;
+                if (contextToDelete != 0L) {
+                    try {
+                        disposeGLInContext(contextToDelete);
+                    } catch (RuntimeException | Error e) {
+                        failure = e;
+                    }
+                    try {
+                        platformCanvas.deleteContext(contextToDelete);
+                    } catch (RuntimeException | Error e) {
+                        failure = appendFailure(failure, e);
+                    }
                 }
+                // prepare for a possible re-adding
+                context = 0L;
+                initCalled = false;
                 try {
-                    platformCanvas.deleteContext(contextToDelete);
+                    platformCanvas.dispose();
                 } catch (RuntimeException | Error e) {
                     failure = appendFailure(failure, e);
                 }
-            }
-            // prepare for a possible re-adding
-            context = 0L;
-            initCalled = false;
-            try {
-                platformCanvas.dispose();
-            } catch (RuntimeException | Error e) {
-                failure = appendFailure(failure, e);
-            }
-            if (failure != null) {
-                rethrow(failure);
+                if (failure != null) {
+                    rethrow(failure);
+                }
+            } finally {
+                disposing = false;
             }
         } finally {
             lifecycleLock.unlock();
         }
     }
 
-    private void disposeGLInContext() {
-        lockAndMakeCurrent(false);
+    private void disposeGLInContext(long contextToDelete) {
+        lockAndMakeCurrent(contextToDelete, false);
         Throwable callbackFailure = null;
         try {
             disposeGL();
@@ -150,6 +161,9 @@ public abstract class AWTGLCanvas extends Canvas {
     }
 
     protected void beforeRender() {
+        if (disposing) {
+            throw new IllegalStateException("Canvas is being disposed");
+        }
         if (context == 0L) {
             try {
                 context = platformCanvas.create(this, data, effective);
@@ -157,17 +171,17 @@ public abstract class AWTGLCanvas extends Canvas {
                 throw new RuntimeException("Exception while creating the OpenGL context", e);
             }
         }
-        lockAndMakeCurrent(true);
+        lockAndMakeCurrent(context, true);
     }
 
-    private void lockAndMakeCurrent(boolean updateFramebuffer) {
+    private void lockAndMakeCurrent(long contextToMakeCurrent, boolean updateFramebuffer) {
         try {
             platformCanvas.lock(); // <- MUST lock on Linux
         } catch (AWTException e) {
             throw new RuntimeException("Failed to lock Canvas", e);
         }
         try {
-            if (!platformCanvas.makeCurrent(context)) {
+            if (!platformCanvas.makeCurrent(contextToMakeCurrent)) {
                 throw new IllegalStateException("Failed to make the OpenGL context current");
             }
             if (updateFramebuffer) {
@@ -351,15 +365,25 @@ public abstract class AWTGLCanvas extends Canvas {
      * Will be called before this canvas's OpenGL context is deleted.
      *
      * <p>The drawing surface is locked and the context is current while this callback runs. It is invoked at most once
-     * for each created context, including a context for which {@link #initGL()} did not complete. It is not invoked when
-     * there is no context or when the context cannot be made current.</p>
+     * for each created context, including when {@link #initGL()} was never called or did not complete. It is not invoked
+     * when there is no context or when the context cannot be made current.</p>
      *
      * <p>This callback runs on the thread that disposes the canvas, which is normally the AWT event-dispatch thread for
      * automatic removal and may differ from the rendering thread. LWJGL's OpenGL and OpenGL ES capabilities are
      * thread-local; applications rendering on another thread must install the corresponding capabilities before issuing
      * GL calls here and clear or restore them before returning.</p>
      *
-     * <p>This callback must not make the context non-current or invoke this canvas's rendering or disposal methods.</p>
+     * <p>Any {@link RuntimeException} or {@link Error} thrown by this callback is rethrown from the disposing operation
+     * after context and platform cleanup have been attempted. Automatic AWT removal also destroys the native peer before
+     * rethrowing the failure.</p>
+     *
+     * <p>During automatic AWT removal, this callback also runs while AWT's tree lock is held. It must not invoke AWT or
+     * Swing operations that acquire the tree lock or synchronously wait for the event-dispatch thread. Post such work
+     * asynchronously instead.</p>
+     *
+     * <p>This callback must not make the context non-current or invoke {@link #render()},
+     * {@link #runInContext(Runnable)}, or {@link #executeInContext(Callable)}. Such method calls fail with an
+     * {@link IllegalStateException}; a reentrant {@link #disposeCanvas()} call is ignored.</p>
      */
     protected void disposeGL() {
     }

--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -64,7 +64,7 @@ public abstract class AWTGLCanvas extends Canvas {
         try {
             Throwable failure = null;
             try {
-                // disposeGL() needs the native peer in order to make the context current.
+                // The context-current cleanup hook needs the native peer to still exist.
                 disposeCanvas();
             } catch (RuntimeException | Error e) {
                 failure = e;
@@ -88,7 +88,8 @@ public abstract class AWTGLCanvas extends Canvas {
     }
 
     /**
-     * Invokes {@link #disposeGL()}, deletes the OpenGL context, and releases platform-specific canvas resources.
+     * Invokes the optional {@link #disposeGL()} context-current cleanup hook, deletes the OpenGL context, and releases
+     * platform-specific canvas resources.
      *
      * <p>If rendering is in progress on another thread, this method waits for that operation to finish before deleting
      * the context. Applications remain responsible for stopping any render loop before disposing the canvas. The
@@ -362,7 +363,18 @@ public abstract class AWTGLCanvas extends Canvas {
     public abstract void paintGL();
 
     /**
-     * Will be called before this canvas's OpenGL context is deleted.
+     * Optional context-current cleanup hook called before this canvas's OpenGL context is deleted.
+     *
+     * <p>Destroying the last context in an OpenGL share group automatically reclaims the group's OpenGL resources.
+     * Applications therefore do not need to override this method merely to delete ordinary OpenGL objects owned by a
+     * context that is the last member of its share group.</p>
+     *
+     * <p>Destroying one context has no effect on shared objects while another context in the share group remains alive.
+     * If this canvas belongs to a share group created through {@link GLData#shareContext}, subclasses can override this
+     * method to delete buffers, programs and shaders, renderbuffers, samplers, sync objects, or textures logically owned
+     * by this canvas. Normal OpenGL deletion semantics still apply, so the implementation may retain an object's storage
+     * while another context continues to reference it. This hook can also perform other cleanup that requires a current
+     * context.</p>
      *
      * <p>The drawing surface is locked and the context is current while this callback runs. It is invoked at most once
      * for each created context, including when {@link #initGL()} was never called or did not complete. It is not invoked

--- a/src/org/lwjgl/opengl/awt/GLData.java
+++ b/src/org/lwjgl/opengl/awt/GLData.java
@@ -68,7 +68,19 @@ public class GLData {
      */
     public int samples;
     /**
-     * The {@link AWTGLCanvas} whose context objects should be shared with the context created using <code>this</code> GLData.
+     * The {@link AWTGLCanvas} whose context should share objects with the context created using this data.
+     *
+     * <p>The referenced canvas's context must already have been created before this canvas creates its context. Backend
+     * support for context sharing may vary.</p>
+     *
+     * <pre>{@code
+     * firstCanvas.render(); // Create the context that will remain alive.
+     *
+     * GLData sharedData = new GLData();
+     * sharedData.shareContext = firstCanvas;
+     * AWTGLCanvas secondCanvas = new MyCanvas(sharedData);
+     * secondCanvas.render(); // Creates a context in the same share group.
+     * }</pre>
      */
     public AWTGLCanvas shareContext;
 

--- a/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
@@ -4,8 +4,11 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.AWTException;
 import java.awt.Canvas;
+import java.awt.EventQueue;
+import java.awt.Frame;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
 import java.awt.Transparency;
 import java.awt.geom.AffineTransform;
@@ -16,8 +19,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -78,15 +84,22 @@ class AWTGLCanvasLifecycleTest {
     }
 
     @Test
-    void disposeCanvasDeletesContextBeforeDrawingSurface() {
+    void disposeCanvasInvokesDisposeGLWhileContextIsCurrentBeforeDeletingIt() {
         RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
-        TestCanvas canvas = new TestCanvas(platform);
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            protected void disposeGL() {
+                assertTrue(platform.isCurrent(42L));
+                platform.calls.add("disposeGL");
+            }
+        };
         canvas.context = 42L;
         canvas.initCalled = true;
 
         canvas.disposeCanvas();
 
-        assertEquals(Arrays.asList("delete:42", "dispose"), platform.calls);
+        assertEquals(Arrays.asList("lock", "makeCurrent:42", "disposeGL", "makeCurrent:0", "unlock",
+                "delete:42", "dispose"), platform.calls);
         assertEquals(0L, canvas.context);
         assertFalse(canvas.initCalled);
     }
@@ -101,9 +114,156 @@ class AWTGLCanvasLifecycleTest {
 
         assertThrows(IllegalStateException.class, canvas::disposeCanvas);
 
-        assertEquals(Arrays.asList("delete:42", "dispose"), platform.calls);
+        assertEquals(Arrays.asList("lock", "makeCurrent:42", "makeCurrent:0", "unlock", "delete:42",
+                "dispose"), platform.calls);
         assertEquals(0L, canvas.context);
         assertFalse(canvas.initCalled);
+    }
+
+    @Test
+    void disposeCanvasStillDeletesContextWhenDisposeGLFails() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        IllegalStateException disposeGLFailure = new IllegalStateException("disposeGL failed");
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            protected void disposeGL() {
+                platform.calls.add("disposeGL");
+                throw disposeGLFailure;
+            }
+        };
+        canvas.context = 42L;
+        canvas.initCalled = true;
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::disposeCanvas);
+
+        assertSame(disposeGLFailure, failure);
+        assertEquals(Arrays.asList("lock", "makeCurrent:42", "disposeGL", "makeCurrent:0", "unlock",
+                "delete:42", "dispose"), platform.calls);
+        assertEquals(0L, canvas.context);
+        assertFalse(canvas.initCalled);
+    }
+
+    @Test
+    void disposeCanvasDoesNotInvokeDisposeGLWhenMakingContextCurrentFails() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.makeCurrentFailureContext = 42L;
+        AtomicBoolean callbackCalled = new AtomicBoolean();
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            protected void disposeGL() {
+                callbackCalled.set(true);
+            }
+        };
+        canvas.context = 42L;
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::disposeCanvas);
+
+        assertEquals("Failed to make the OpenGL context current", failure.getMessage());
+        assertFalse(callbackCalled.get());
+        assertEquals(Arrays.asList("lock", "makeCurrent:42", "makeCurrent:0", "unlock", "delete:42",
+                "dispose"), platform.calls);
+        assertEquals(0L, canvas.context);
+    }
+
+    @Test
+    void disposeCanvasDoesNotQueryFramebufferSizeBeforeDisposeGL() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.framebufferSizeFailure = new IllegalStateException("size query failed");
+        AtomicBoolean callbackCalled = new AtomicBoolean();
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            protected void disposeGL() {
+                callbackCalled.set(true);
+            }
+        };
+        canvas.context = 42L;
+
+        canvas.disposeCanvas();
+
+        assertTrue(callbackCalled.get());
+        assertEquals(Arrays.asList("lock", "makeCurrent:42", "makeCurrent:0", "unlock", "delete:42",
+                "dispose"), platform.calls);
+    }
+
+    @Test
+    void disposeCanvasPreservesCallbackFailureWhenLaterCleanupAlsoFails() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        platform.makeCurrentFailureContext = 0L;
+        platform.deleteFailure = new IllegalStateException("delete failed");
+        platform.disposeFailure = new IllegalStateException("platform dispose failed");
+        IllegalStateException disposeGLFailure = new IllegalStateException("disposeGL failed");
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            protected void disposeGL() {
+                platform.calls.add("disposeGL");
+                throw disposeGLFailure;
+            }
+        };
+        canvas.context = 42L;
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::disposeCanvas);
+
+        assertSame(disposeGLFailure, failure);
+        assertEquals(3, failure.getSuppressed().length);
+        assertEquals("Failed to clear the current OpenGL context", failure.getSuppressed()[0].getMessage());
+        assertSame(platform.deleteFailure, failure.getSuppressed()[1]);
+        assertSame(platform.disposeFailure, failure.getSuppressed()[2]);
+        assertEquals(Arrays.asList("lock", "makeCurrent:42", "disposeGL", "makeCurrent:0", "unlock",
+                "delete:42", "dispose"), platform.calls);
+        assertEquals(0L, canvas.context);
+    }
+
+    @Test
+    void disposeGLIsInvokedOnlyOncePerContext() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        AtomicInteger callbackCalls = new AtomicInteger();
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            protected void disposeGL() {
+                callbackCalls.incrementAndGet();
+            }
+        };
+        canvas.context = 42L;
+
+        canvas.disposeCanvas();
+        canvas.disposeCanvas();
+
+        assertEquals(1, callbackCalls.get());
+        assertEquals(Arrays.asList("lock", "makeCurrent:42", "makeCurrent:0", "unlock", "delete:42",
+                "dispose", "dispose"), platform.calls);
+    }
+
+    @Test
+    void removeNotifyInvokesDisposeGLBeforeDestroyingNativePeer() throws Exception {
+        assumeFalse(GraphicsEnvironment.isHeadless());
+        AtomicBoolean callbackCalled = new AtomicBoolean();
+        AtomicBoolean callbackSawDisplayableCanvas = new AtomicBoolean();
+
+        EventQueue.invokeAndWait(() -> {
+            Frame frame = new Frame();
+            try {
+                RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+                TestCanvas canvas = new TestCanvas(platform) {
+                    @Override
+                    protected void disposeGL() {
+                        callbackCalled.set(true);
+                        callbackSawDisplayableCanvas.set(isDisplayable());
+                    }
+                };
+                frame.add(canvas);
+                frame.pack();
+                assertTrue(canvas.isDisplayable());
+                canvas.context = 42L;
+
+                frame.remove(canvas);
+
+                assertTrue(callbackCalled.get());
+                assertTrue(callbackSawDisplayableCanvas.get());
+                assertFalse(canvas.isDisplayable());
+            } finally {
+                frame.dispose();
+            }
+        });
     }
 
     @Test
@@ -288,7 +448,8 @@ class AWTGLCanvasLifecycleTest {
         assertNull(renderFailure.get(), "Rendering failed");
         assertNull(disposeFailure.get(), "Disposal failed");
         assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "paint:start", "paint:end",
-                "makeCurrent:0", "unlock", "delete:42", "dispose"), platform.calls);
+                "makeCurrent:0", "unlock", "lock", "makeCurrent:42", "makeCurrent:0", "unlock",
+                "delete:42", "dispose"), platform.calls);
     }
 
     @Test
@@ -435,9 +596,11 @@ class AWTGLCanvasLifecycleTest {
         final List<String> calls = Collections.synchronizedList(new ArrayList<>());
         final CountDownLatch deleteCalled = new CountDownLatch(1);
         RuntimeException deleteFailure;
+        RuntimeException disposeFailure;
         RuntimeException framebufferSizeFailure;
         long makeCurrentFailureContext = Long.MIN_VALUE;
         long makeCurrentExceptionContext = Long.MIN_VALUE;
+        long currentContext;
         boolean reportsFramebufferSize = true;
         int framebufferWidth;
         int framebufferHeight;
@@ -464,12 +627,16 @@ class AWTGLCanvasLifecycleTest {
             if (context == makeCurrentExceptionContext) {
                 throw new IllegalStateException("make current failed");
             }
-            return context != makeCurrentFailureContext;
+            if (context == makeCurrentFailureContext) {
+                return false;
+            }
+            currentContext = context;
+            return true;
         }
 
         @Override
         public boolean isCurrent(long context) {
-            return false;
+            return currentContext == context;
         }
 
         @Override
@@ -509,6 +676,9 @@ class AWTGLCanvasLifecycleTest {
         @Override
         public void dispose() {
             calls.add("dispose");
+            if (disposeFailure != null) {
+                throw disposeFailure;
+            }
         }
     }
 }

--- a/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
@@ -234,6 +234,69 @@ class AWTGLCanvasLifecycleTest {
     }
 
     @Test
+    void contextCreatedByRunInContextIsDisposedWithoutCallingInitGL() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        AtomicBoolean initGLCalled = new AtomicBoolean();
+        AtomicBoolean disposeGLCalled = new AtomicBoolean();
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            public void initGL() {
+                initGLCalled.set(true);
+            }
+
+            @Override
+            protected void disposeGL() {
+                assertTrue(platform.isCurrent(42L));
+                disposeGLCalled.set(true);
+                platform.calls.add("disposeGL");
+            }
+        };
+
+        canvas.runInContext(() -> platform.calls.add("work"));
+        assertFalse(initGLCalled.get());
+        assertFalse(canvas.initCalled);
+
+        canvas.disposeCanvas();
+
+        assertTrue(disposeGLCalled.get());
+        assertEquals(Arrays.asList("create", "lock", "makeCurrent:42", "work", "makeCurrent:0", "unlock",
+                "lock", "makeCurrent:42", "disposeGL", "makeCurrent:0", "unlock", "delete:42", "dispose"),
+                platform.calls);
+    }
+
+    @Test
+    void disposeGLPreventsReentrantLifecycleOperationsWithoutRelockingDrawingSurface() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        AtomicInteger callbackCalls = new AtomicInteger();
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            protected void disposeGL() {
+                callbackCalls.incrementAndGet();
+
+                disposeCanvas();
+
+                IllegalStateException renderFailure = assertThrows(IllegalStateException.class, this::render);
+                assertEquals("Canvas is being disposed", renderFailure.getMessage());
+                IllegalStateException runFailure = assertThrows(IllegalStateException.class,
+                        () -> runInContext(() -> {}));
+                assertEquals("Canvas is being disposed", runFailure.getMessage());
+                IllegalStateException executeFailure = assertThrows(IllegalStateException.class,
+                        () -> executeInContext(() -> null));
+                assertEquals("Canvas is being disposed", executeFailure.getMessage());
+
+                platform.calls.add("disposeGL");
+            }
+        };
+        canvas.context = 42L;
+
+        canvas.disposeCanvas();
+
+        assertEquals(1, callbackCalls.get());
+        assertEquals(Arrays.asList("lock", "makeCurrent:42", "disposeGL", "makeCurrent:0", "unlock",
+                "delete:42", "dispose"), platform.calls);
+    }
+
+    @Test
     void removeNotifyInvokesDisposeGLBeforeDestroyingNativePeer() throws Exception {
         assumeFalse(GraphicsEnvironment.isHeadless());
         AtomicBoolean callbackCalled = new AtomicBoolean();
@@ -260,6 +323,76 @@ class AWTGLCanvasLifecycleTest {
                 assertTrue(callbackCalled.get());
                 assertTrue(callbackSawDisplayableCanvas.get());
                 assertFalse(canvas.isDisplayable());
+            } finally {
+                frame.dispose();
+            }
+        });
+    }
+
+    @Test
+    void windowDisposeInvokesDisposeGLBeforeDestroyingNativePeer() throws Exception {
+        assumeFalse(GraphicsEnvironment.isHeadless());
+        AtomicBoolean callbackCalled = new AtomicBoolean();
+        AtomicBoolean callbackSawDisplayableCanvas = new AtomicBoolean();
+
+        EventQueue.invokeAndWait(() -> {
+            Frame frame = new Frame();
+            try {
+                RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+                TestCanvas canvas = new TestCanvas(platform) {
+                    @Override
+                    protected void disposeGL() {
+                        callbackCalled.set(true);
+                        callbackSawDisplayableCanvas.set(isDisplayable());
+                    }
+                };
+                frame.add(canvas);
+                frame.pack();
+                assertTrue(canvas.isDisplayable());
+                canvas.context = 42L;
+
+                frame.dispose();
+
+                assertTrue(callbackCalled.get());
+                assertTrue(callbackSawDisplayableCanvas.get());
+                assertFalse(canvas.isDisplayable());
+            } finally {
+                frame.dispose();
+            }
+        });
+    }
+
+    @Test
+    void awtRemovalDisposesOncePerContextAcrossCanvasReAdd() throws Exception {
+        assumeFalse(GraphicsEnvironment.isHeadless());
+        AtomicInteger callbackCalls = new AtomicInteger();
+
+        EventQueue.invokeAndWait(() -> {
+            Frame frame = new Frame();
+            try {
+                RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+                TestCanvas canvas = new TestCanvas(platform) {
+                    @Override
+                    protected void disposeGL() {
+                        assertTrue(isDisplayable());
+                        callbackCalls.incrementAndGet();
+                    }
+                };
+                frame.add(canvas);
+                frame.pack();
+                canvas.context = 42L;
+
+                frame.remove(canvas);
+                assertFalse(canvas.isDisplayable());
+
+                frame.add(canvas);
+                frame.pack();
+                assertTrue(canvas.isDisplayable());
+                canvas.context = 84L;
+
+                frame.remove(canvas);
+                assertFalse(canvas.isDisplayable());
+                assertEquals(2, callbackCalls.get());
             } finally {
                 frame.dispose();
             }

--- a/test/org/lwjgl/opengl/awt/AWTThreadTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTThreadTest.java
@@ -89,8 +89,8 @@ public class AWTThreadTest {
                     canvas.render();
                     try {
                         if (signalTerminate.tryAcquire(10, TimeUnit.MILLISECONDS)) {
-                            GL.setCapabilities(null);
                             canvas.doDisposeCanvas();
+                            GL.setCapabilities(null);
                             signalTerminated.release();
                             return;
                         }

--- a/test/org/lwjgl/opengl/awt/CompareScreenshotTest.java
+++ b/test/org/lwjgl/opengl/awt/CompareScreenshotTest.java
@@ -44,15 +44,20 @@ import static org.lwjgl.opengl.GL11.GL_QUADS;
 import static org.lwjgl.opengl.GL11.GL_READ_BUFFER;
 import static org.lwjgl.opengl.GL11.GL_RGBA;
 import static org.lwjgl.opengl.GL11.GL_RGBA8;
+import static org.lwjgl.opengl.GL11.GL_TEXTURE_2D;
 import static org.lwjgl.opengl.GL11.GL_UNSIGNED_BYTE;
 import static org.lwjgl.opengl.GL11.glBegin;
+import static org.lwjgl.opengl.GL11.glBindTexture;
 import static org.lwjgl.opengl.GL11.glClear;
 import static org.lwjgl.opengl.GL11.glClearColor;
 import static org.lwjgl.opengl.GL11.glColor3f;
+import static org.lwjgl.opengl.GL11.glDeleteTextures;
 import static org.lwjgl.opengl.GL11.glDrawBuffer;
 import static org.lwjgl.opengl.GL11.glEnd;
 import static org.lwjgl.opengl.GL11.glFinish;
+import static org.lwjgl.opengl.GL11.glGenTextures;
 import static org.lwjgl.opengl.GL11.glGetInteger;
+import static org.lwjgl.opengl.GL11.glIsTexture;
 import static org.lwjgl.opengl.GL11.glPixelStorei;
 import static org.lwjgl.opengl.GL11.glReadBuffer;
 import static org.lwjgl.opengl.GL11.glReadPixels;
@@ -474,6 +479,7 @@ public class CompareScreenshotTest {
     private static class DemoCanvas extends AWTGLCanvas {
         private boolean captureRequested;
         private BufferedImage framebufferImage;
+        private int texture;
 
         public DemoCanvas(GLData data) {
             super(data);
@@ -501,6 +507,9 @@ public class CompareScreenshotTest {
             System.out.println("OpenGL version: " + effective.majorVersion + "." + effective.minorVersion + " (Profile: " + effective.profile + ")");
             createCapabilities();
             glClearColor(0.3f, 0.4f, 0.5f, 1);
+            texture = glGenTextures();
+            glBindTexture(GL_TEXTURE_2D, texture);
+            glBindTexture(GL_TEXTURE_2D, 0);
         }
 
         public void paintGL() {
@@ -511,6 +520,15 @@ public class CompareScreenshotTest {
                 framebufferImage = captureOffscreen(getWidth(), getHeight());
             }
             swapBuffers();
+        }
+
+        @Override
+        protected void disposeGL() {
+            Assertions.assertTrue(platformCanvas.isCurrent(context));
+            Assertions.assertTrue(glIsTexture(texture));
+            glDeleteTextures(texture);
+            Assertions.assertFalse(glIsTexture(texture));
+            texture = 0;
         }
 
         private void drawScene(int w, int h) {

--- a/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
+++ b/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
@@ -2,7 +2,6 @@ package org.lwjgl.opengl.awt;
 
 import org.junit.jupiter.api.Test;
 import org.lwjgl.opengl.GL;
-import org.lwjgl.opengl.GLCapabilities;
 
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -15,14 +14,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.lwjgl.opengl.GL11.GL_TEXTURE_2D;
-import static org.lwjgl.opengl.GL11.glBindTexture;
-import static org.lwjgl.opengl.GL11.glDeleteTextures;
-import static org.lwjgl.opengl.GL11.glGenTextures;
-import static org.lwjgl.opengl.GL11.glIsTexture;
 
 class JAWTDrawingSurfaceThreadLifetimeTest {
-    // Repeating the complete peer and context teardown catches resource leaks that a one-shot smoke test misses.
+    // Repeating the complete peer and context teardown catches native lifecycle failures that a one-shot smoke misses.
     private static final int LIFECYCLE_CYCLES = 10;
 
     @Test
@@ -135,8 +129,6 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
 
     private static final class LifecycleCanvas extends AWTGLCanvas {
         private final int cycle;
-        private GLCapabilities capabilities;
-        private int texture;
         private boolean disposeGLCalled;
 
         LifecycleCanvas(int cycle) {
@@ -145,10 +137,7 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
 
         @Override
         public void initGL() {
-            capabilities = GL.createCapabilities();
-            texture = glGenTextures();
-            glBindTexture(GL_TEXTURE_2D, texture);
-            glBindTexture(GL_TEXTURE_2D, 0);
+            GL.createCapabilities();
         }
 
         @Override
@@ -160,18 +149,7 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
         protected void disposeGL() {
             assertTrue(platformCanvas.isCurrent(context),
                     "OpenGL context was not current during disposal in cycle " + cycle);
-            GL.setCapabilities(capabilities);
-            try {
-                assertTrue(glIsTexture(texture),
-                        "Test texture did not exist before disposal in cycle " + cycle);
-                glDeleteTextures(texture);
-                assertFalse(glIsTexture(texture),
-                        "Test texture still existed after disposal in cycle " + cycle);
-                texture = 0;
-                disposeGLCalled = true;
-            } finally {
-                GL.setCapabilities(null);
-            }
+            disposeGLCalled = true;
         }
     }
 }

--- a/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
+++ b/test/org/lwjgl/opengl/awt/JAWTDrawingSurfaceThreadLifetimeTest.java
@@ -2,6 +2,7 @@ package org.lwjgl.opengl.awt;
 
 import org.junit.jupiter.api.Test;
 import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GLCapabilities;
 
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -12,7 +13,13 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.lwjgl.opengl.GL11.GL_TEXTURE_2D;
+import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.lwjgl.opengl.GL11.glDeleteTextures;
+import static org.lwjgl.opengl.GL11.glGenTextures;
+import static org.lwjgl.opengl.GL11.glIsTexture;
 
 class JAWTDrawingSurfaceThreadLifetimeTest {
     // Repeating the complete peer and context teardown catches resource leaks that a one-shot smoke test misses.
@@ -29,17 +36,7 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
         AtomicReference<Lifecycle> lifecycleRef = new AtomicReference<>();
 
         SwingUtilities.invokeAndWait(() -> {
-            AWTGLCanvas canvas = new AWTGLCanvas(new GLData()) {
-                @Override
-                public void initGL() {
-                    GL.createCapabilities();
-                }
-
-                @Override
-                public void paintGL() {
-                    swapBuffers();
-                }
-            };
+            LifecycleCanvas canvas = new LifecycleCanvas(cycle);
             canvas.setPreferredSize(new Dimension(320, 240));
 
             JFrame frame = new JFrame("dispose-after-render-thread-exits-" + cycle);
@@ -58,6 +55,8 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
                 lifecycle.canvas.render();
             } catch (Throwable t) {
                 renderFailure.set(t);
+            } finally {
+                GL.setCapabilities(null);
             }
         }, "short-lived-renderer-" + cycle);
         renderer.setDaemon(true);
@@ -92,6 +91,8 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
                         "OpenGL context was not cleared in cycle " + cycle);
                 assertFalse(lifecycle.canvas.initCalled,
                         "Canvas remained initialized after removal in cycle " + cycle);
+                assertTrue(lifecycle.canvas.disposeGLCalled,
+                        "disposeGL was not called in cycle " + cycle);
             });
         } catch (Throwable cleanupFailure) {
             failure = unwrapInvocationFailure(cleanupFailure);
@@ -124,11 +125,53 @@ class JAWTDrawingSurfaceThreadLifetimeTest {
 
     private static class Lifecycle {
         final JFrame frame;
-        final AWTGLCanvas canvas;
+        final LifecycleCanvas canvas;
 
-        Lifecycle(JFrame frame, AWTGLCanvas canvas) {
+        Lifecycle(JFrame frame, LifecycleCanvas canvas) {
             this.frame = frame;
             this.canvas = canvas;
+        }
+    }
+
+    private static final class LifecycleCanvas extends AWTGLCanvas {
+        private final int cycle;
+        private GLCapabilities capabilities;
+        private int texture;
+        private boolean disposeGLCalled;
+
+        LifecycleCanvas(int cycle) {
+            this.cycle = cycle;
+        }
+
+        @Override
+        public void initGL() {
+            capabilities = GL.createCapabilities();
+            texture = glGenTextures();
+            glBindTexture(GL_TEXTURE_2D, texture);
+            glBindTexture(GL_TEXTURE_2D, 0);
+        }
+
+        @Override
+        public void paintGL() {
+            swapBuffers();
+        }
+
+        @Override
+        protected void disposeGL() {
+            assertTrue(platformCanvas.isCurrent(context),
+                    "OpenGL context was not current during disposal in cycle " + cycle);
+            GL.setCapabilities(capabilities);
+            try {
+                assertTrue(glIsTexture(texture),
+                        "Test texture did not exist before disposal in cycle " + cycle);
+                glDeleteTextures(texture);
+                assertFalse(glIsTexture(texture),
+                        "Test texture still existed after disposal in cycle " + cycle);
+                texture = 0;
+                disposeGLCalled = true;
+            } finally {
+                GL.setCapabilities(null);
+            }
         }
     }
 }

--- a/test/org/lwjgl/opengl/awt/SharedContextDisposalTest.java
+++ b/test/org/lwjgl/opengl/awt/SharedContextDisposalTest.java
@@ -1,0 +1,157 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GLCapabilities;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import java.awt.Dimension;
+import java.awt.GraphicsEnvironment;
+import java.awt.GridLayout;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.lwjgl.opengl.GL11.GL_TEXTURE_2D;
+import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.lwjgl.opengl.GL11.glDeleteTextures;
+import static org.lwjgl.opengl.GL11.glGenTextures;
+import static org.lwjgl.opengl.GL11.glIsTexture;
+
+@DisabledOnOs(value = OS.MAC, disabledReason = "The macOS backend does not support GLData.shareContext")
+class SharedContextDisposalTest {
+    @Test
+    void deletesCanvasOwnedSharedObjectWhileAnotherContextSurvives() throws Exception {
+        assumeFalse(GraphicsEnvironment.isHeadless());
+
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                OwnerCanvas owner = new OwnerCanvas();
+                owner.setPreferredSize(new Dimension(160, 120));
+
+                GLData sharedData = new GLData();
+                sharedData.shareContext = owner;
+                TransientCanvas transientCanvas = new TransientCanvas(sharedData);
+                transientCanvas.setPreferredSize(new Dimension(160, 120));
+
+                JPanel canvases = new JPanel(new GridLayout(1, 2));
+                canvases.add(owner);
+                canvases.add(transientCanvas);
+
+                JFrame frame = new JFrame("shared-context-disposal");
+                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                frame.setContentPane(canvases);
+                frame.pack();
+                frame.setVisible(true);
+                frameRef.set(frame);
+
+                owner.render();
+                transientCanvas.render();
+
+                int deletedTexture = transientCanvas.deletedTexture;
+                int survivingTexture = transientCanvas.survivingTexture;
+                assertTrue(owner.isTexture(deletedTexture));
+                assertTrue(owner.isTexture(survivingTexture));
+
+                canvases.remove(transientCanvas);
+
+                assertTrue(transientCanvas.disposeGLCalled);
+                assertFalse(owner.isTexture(deletedTexture),
+                        "disposeGL did not delete the canvas-owned object from the surviving share group");
+                assertTrue(owner.isTexture(survivingTexture),
+                        "Destroying one context unexpectedly deleted an undeleted shared object");
+
+                owner.deleteTexture(survivingTexture);
+                assertFalse(owner.isTexture(survivingTexture));
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                GL.setCapabilities(null);
+                JFrame frame = frameRef.get();
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private abstract static class SharedCanvas extends AWTGLCanvas {
+        GLCapabilities capabilities;
+
+        SharedCanvas() {
+        }
+
+        SharedCanvas(GLData data) {
+            super(data);
+        }
+
+        @Override
+        public void initGL() {
+            capabilities = GL.createCapabilities();
+        }
+
+        @Override
+        public void paintGL() {
+            swapBuffers();
+        }
+
+        final boolean isTexture(int texture) {
+            final boolean[] result = new boolean[1];
+            runInContext(() -> withCapabilities(() -> result[0] = glIsTexture(texture)));
+            return result[0];
+        }
+
+        final void deleteTexture(int texture) {
+            runInContext(() -> withCapabilities(() -> glDeleteTextures(texture)));
+        }
+
+        final void withCapabilities(Runnable action) {
+            GL.setCapabilities(capabilities);
+            try {
+                action.run();
+            } finally {
+                GL.setCapabilities(null);
+            }
+        }
+    }
+
+    private static final class OwnerCanvas extends SharedCanvas {
+    }
+
+    private static final class TransientCanvas extends SharedCanvas {
+        int deletedTexture;
+        int survivingTexture;
+        boolean disposeGLCalled;
+
+        TransientCanvas(GLData data) {
+            super(data);
+        }
+
+        @Override
+        public void initGL() {
+            super.initGL();
+            deletedTexture = createTexture();
+            survivingTexture = createTexture();
+        }
+
+        @Override
+        protected void disposeGL() {
+            assertTrue(platformCanvas.isCurrent(context));
+            withCapabilities(() -> glDeleteTextures(deletedTexture));
+            disposeGLCalled = true;
+        }
+
+        private static int createTexture() {
+            int texture = glGenTextures();
+            glBindTexture(GL_TEXTURE_2D, texture);
+            glBindTexture(GL_TEXTURE_2D, 0);
+            return texture;
+        }
+    }
+}


### PR DESCRIPTION
`AWTGLCanvas` currently destroys its OpenGL context when the canvas becomes undisplayable, but applications have no reliable point to release textures, buffers, shaders, FBOs, and other GL resources first. Java documents that [`removeNotify()` destroys the component’s native screen resource](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/Component.html#removeNotify()), so this cleanup must happen before the native peer and context are removed. This requirement has also led [Decima Workshop to maintain its own `disposeGL()` extension](https://github.com/ShadelessFox/decima-workshop/blob/59c6ea825021d0d150fe6ddd8f3181ddb8097c92/bundle-lwjgl/src/main/java/com/shade/gl/awt/AWTGLCanvas.java).

This adds a protected no-op `disposeGL()` callback. It is invoked at most once for each created context—even if `initGL()` was never called or did not complete—while the drawing surface is locked, the native peer still exists, and the context is current. It is skipped if the context cannot be made current. Applications can override it to call functions such as [`glDeleteTextures`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteTextures.xhtml).

`disposeCanvas()` still attempts context deletion and platform cleanup if making the context current or the callback fails, and automatic AWT removal still proceeds with native peer removal. The first failure is rethrown afterward. Reentrant disposal is ignored, while attempts to render or execute context callbacks during disposal fail explicitly.

The callback is protected because subclasses should override it, but only `AWTGLCanvas` should invoke it.

---

Example:

```java
class MyCanvas extends AWTGLCanvas {
    private int texture;

    @Override
    public void initGL() {
        GL.createCapabilities();
        texture = glGenTextures();
        // Upload texture data...
    }

    @Override
    public void paintGL() {
        glBindTexture(GL_TEXTURE_2D, texture);
        // Render...
    }

    @Override
    protected void disposeGL() {
        if (texture != 0) {
            glDeleteTextures(texture);
            texture = 0;
        }
    }
}
```

When the canvas is removed or its window is disposed, `disposeGL()` runs before the context is destroyed. Buffers, shaders, VAOs, and FBOs can be released there in the same way.

---

The callback uses the existing platform context abstraction, so it applies to GLX, EGL, WGL, and macOS contexts. When rendering and disposal happen on different threads, applications must install the correct `GLCapabilities` during the callback because [LWJGL stores capabilities per thread and current context](https://javadoc.lwjgl.org/org/lwjgl/opengl/GL.html).

During automatic AWT removal, the callback also runs while AWT’s tree lock is held, so implementations must not perform synchronous AWT or Swing work from `disposeGL()`.

Tests cover callback ordering, failure cleanup, contexts created without `initGL()`, reentrant lifecycle calls, `Window.dispose()`, removal and re-addition, native-peer validity, and real OpenGL resource deletion on same-thread and cross-thread lifecycles. The full suite was also run locally on macOS, including live-frame disposal with real texture deletion and the repeated cross-thread lifecycle test.