### PR TITLE
Add context version selection policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Full code samples:
 
 ### OpenGL
 
-In order to create an OpenGL 3.3 core profile context with 4 sample MSAA, use:
+In order to create the highest available OpenGL core profile context that is at least 3.3, with 4 sample MSAA, use:
 
 ```Java
 JFrame frame = new JFrame("AWT test");
@@ -60,6 +60,7 @@ GLData data = new GLData();
 data.majorVersion = 3;
 data.minorVersion = 3;
 data.profile = GLData.Profile.CORE;
+data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
 data.samples = 4;
 frame.add(new AWTGLCanvas(data) {
   public void initGL() {
@@ -68,6 +69,11 @@ frame.add(new AWTGLCanvas(data) {
   }
 });
 ```
+
+`EXACT` is the default version policy and preserves the traditional single-version request. `HIGHEST` ignores the
+configured version fields and requests the highest profile-compatible version without setting a minimum. The version
+actually selected by the platform is available through the canvas's `effective.majorVersion` and
+`effective.minorVersion` fields.
 
 ### Vulkan
 

--- a/src/org/lwjgl/opengl/awt/GLData.java
+++ b/src/org/lwjgl/opengl/awt/GLData.java
@@ -84,24 +84,45 @@ public class GLData {
         GL, GLES
 	}
 
+    /**
+     * Controls how {@link #majorVersion} and {@link #minorVersion} are used when creating a context.
+     */
+    public enum VersionPolicy {
+        /** Request the configured version once, preserving the traditional behavior. */
+        EXACT,
+        /** Try supported, profile-compatible versions from the platform maximum down to the configured minimum. */
+        AT_LEAST,
+        /** Try supported, profile-compatible versions from the platform maximum down, ignoring the configured version. */
+        HIGHEST
+    }
+
     public enum ReleaseBehavior {
         NONE, FLUSH
 	}
 
     /**
-     * The major GL context version to use. It defaults to 0 for "not specified".
+     * The major GL context version to use. It defaults to 0 for "not specified". With
+     * {@link VersionPolicy#AT_LEAST}, this is the minimum acceptable major version.
      */
     public int majorVersion;
     /**
-     * The minor GL context version to use. If {@link #majorVersion} is 0 this field is unused.
+     * The minor GL context version to use. If {@link #majorVersion} is 0 this field is unused. With
+     * {@link VersionPolicy#AT_LEAST}, this is the minimum acceptable minor version.
      */
     public int minorVersion;
     /**
-     * Whether a forward-compatible context should be created. This has only an effect when ({@link #majorVersion}.{@link #minorVersion}) is at least 3.2.
+     * The policy used to select a GL context version. It defaults to {@link VersionPolicy#EXACT}, which preserves
+     * the traditional single-request behavior. {@link VersionPolicy#HIGHEST} ignores the configured version.
+     */
+    public VersionPolicy versionPolicy = VersionPolicy.EXACT;
+    /**
+     * Whether a forward-compatible context should be created. This is only valid for OpenGL 3.0 and later. With
+     * {@link VersionPolicy#HIGHEST}, versions below 3.0 are not considered.
      */
     public boolean forwardCompatible;
     /**
-     * The profile to use. This is only valid when ({@link #majorVersion}.{@link #minorVersion}) is at least 3.0.
+     * The profile to use. This is only valid for desktop OpenGL 3.2 and later. With
+     * {@link VersionPolicy#HIGHEST}, versions below 3.2 are not considered.
      */
     public Profile profile;
     /**

--- a/src/org/lwjgl/opengl/awt/GLUtil.java
+++ b/src/org/lwjgl/opengl/awt/GLUtil.java
@@ -1,8 +1,23 @@
 package org.lwjgl.opengl.awt;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.lwjgl.opengl.awt.GLData.API;
+import org.lwjgl.opengl.awt.GLData.VersionPolicy;
 
 class GLUtil {
+    private static final ContextVersion[] GL_VERSIONS = {
+            version(4, 6), version(4, 5), version(4, 4), version(4, 3), version(4, 2), version(4, 1), version(4, 0),
+            version(3, 3), version(3, 2), version(3, 1), version(3, 0),
+            version(2, 1), version(2, 0),
+            version(1, 5), version(1, 4), version(1, 3), version(1, 2), version(1, 1), version(1, 0)
+    };
+    private static final ContextVersion[] GLES_VERSIONS = {
+            version(3, 2), version(3, 1), version(3, 0),
+            version(2, 0), version(1, 1), version(1, 0)
+    };
     
     static boolean atLeast32(int major, int minor) {
         return major == 3 && minor >= 2 || major > 3;
@@ -13,15 +28,67 @@ class GLUtil {
     }
 
     static boolean validVersionGL(int major, int minor) {
-        return (major == 0 && minor == 0)
-                || // unspecified gets highest supported version on Nvidia
-                (major >= 1 && minor >= 0) && (major != 1 || minor <= 5) && (major != 2 || minor <= 1) && (major != 3 || minor <= 3)
-                && (major != 4 || minor <= 5);
+        return major == 0 && minor == 0 || contains(GL_VERSIONS, major, minor);
     }
 
     public static boolean validVersionGLES(int major, int minor) {
-        return (major == 0 && minor == 0) || // unspecified gets 1.1 on Nvidia
-                (major >= 1 && minor >= 0) && (major != 1 || minor <= 1) && (major != 2 || minor <= 0);
+        return major == 0 && minor == 0 || contains(GLES_VERSIONS, major, minor);
+    }
+
+    static List<ContextVersion> contextVersionCandidates(GLData data, int maximumMajor, int maximumMinor) {
+        if (data.versionPolicy == VersionPolicy.EXACT) {
+            return Collections.singletonList(version(data.majorVersion, data.minorVersion));
+        }
+
+        ContextVersion[] versions = data.api == API.GLES ? GLES_VERSIONS : GL_VERSIONS;
+        List<ContextVersion> candidates = new ArrayList<>();
+        for (ContextVersion version : versions) {
+            if (compare(version.major, version.minor, maximumMajor, maximumMinor) > 0) {
+                continue;
+            }
+            if (data.versionPolicy == VersionPolicy.AT_LEAST
+                    && compare(version.major, version.minor, data.majorVersion, data.minorVersion) < 0) {
+                continue;
+            }
+            if (data.api == API.GL && data.profile != null && !atLeast32(version.major, version.minor)) {
+                continue;
+            }
+            if (data.forwardCompatible && !atLeast30(version.major, version.minor)) {
+                continue;
+            }
+            candidates.add(version);
+        }
+        return candidates;
+    }
+
+    static String describeVersionRequest(GLData data) {
+        if (data.versionPolicy == VersionPolicy.HIGHEST) {
+            return "the highest supported " + apiName(data.api) + " version";
+        }
+        return (data.api == API.GLES ? "OpenGL ES " : "OpenGL ")
+                + data.majorVersion + "." + data.minorVersion + " or later";
+    }
+
+    private static String apiName(API api) {
+        return api == API.GLES ? "OpenGL ES" : "OpenGL";
+    }
+
+    private static int compare(int major, int minor, int otherMajor, int otherMinor) {
+        int majorComparison = Integer.compare(major, otherMajor);
+        return majorComparison != 0 ? majorComparison : Integer.compare(minor, otherMinor);
+    }
+
+    private static boolean contains(ContextVersion[] versions, int major, int minor) {
+        for (ContextVersion version : versions) {
+            if (version.major == major && version.minor == minor) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ContextVersion version(int major, int minor) {
+        return new ContextVersion(major, minor);
     }
 
     /**
@@ -49,23 +116,9 @@ class GLUtil {
         if (attribs.depthSize < 0) {
             throw new IllegalArgumentException("Depth bits cannot be less than 0");
         }
-        if (attribs.forwardCompatible && !atLeast30(attribs.majorVersion, attribs.minorVersion)) {
-            throw new IllegalArgumentException("Forward-compatibility is only defined for OpenGL version 3.0 and above");
-        }
+        validateVersionAttributes(attribs);
         if (attribs.samples < 0) {
             throw new IllegalArgumentException("Invalid samples count");
-        }
-        if (attribs.profile != null && !atLeast32(attribs.majorVersion, attribs.minorVersion)) {
-            throw new IllegalArgumentException("Context profiles are only defined for OpenGL version 3.2 and above");
-        }
-        if (attribs.api == null) {
-            throw new IllegalArgumentException("Unspecified client API");
-        }
-        if (attribs.api == API.GL && !validVersionGL(attribs.majorVersion, attribs.minorVersion)) {
-            throw new IllegalArgumentException("Invalid OpenGL version");
-        }
-        if (attribs.api == API.GLES && !validVersionGLES(attribs.majorVersion, attribs.minorVersion)) {
-            throw new IllegalArgumentException("Invalid OpenGL ES version");
         }
         if (!attribs.doubleBuffer && attribs.swapInterval != null) {
             throw new IllegalArgumentException("Swap interval set but not using double buffering");
@@ -93,6 +146,53 @@ class GLUtil {
         }
         if (attribs.contextResetIsolation && !attribs.robustness) {
             throw new IllegalArgumentException("Context reset isolation requested but not using robustness");
+        }
+    }
+
+    static void validateVersionAttributes(GLData attribs) {
+        if (attribs.versionPolicy == null) {
+            throw new IllegalArgumentException("Unspecified context version policy");
+        }
+        if (attribs.api == null) {
+            throw new IllegalArgumentException("Unspecified client API");
+        }
+        if (attribs.api == API.GLES && attribs.profile != null) {
+            throw new IllegalArgumentException("OpenGL ES does not support desktop OpenGL context profiles");
+        }
+        if (attribs.forwardCompatible && attribs.versionPolicy != VersionPolicy.HIGHEST
+                && !atLeast30(attribs.majorVersion, attribs.minorVersion)) {
+            throw new IllegalArgumentException("Forward-compatibility is only defined for OpenGL version 3.0 and above");
+        }
+        if (attribs.profile != null && attribs.versionPolicy != VersionPolicy.HIGHEST
+                && !atLeast32(attribs.majorVersion, attribs.minorVersion)) {
+            throw new IllegalArgumentException("Context profiles are only defined for OpenGL version 3.2 and above");
+        }
+        if (attribs.versionPolicy == VersionPolicy.HIGHEST) {
+            return;
+        }
+        if (attribs.versionPolicy == VersionPolicy.AT_LEAST && attribs.majorVersion == 0) {
+            throw new IllegalArgumentException("AT_LEAST context version policy requires a minimum version");
+        }
+        if (attribs.api == API.GL && !validVersionGL(attribs.majorVersion, attribs.minorVersion)) {
+            throw new IllegalArgumentException("Invalid OpenGL version");
+        }
+        if (attribs.api == API.GLES && !validVersionGLES(attribs.majorVersion, attribs.minorVersion)) {
+            throw new IllegalArgumentException("Invalid OpenGL ES version");
+        }
+    }
+
+    static final class ContextVersion {
+        final int major;
+        final int minor;
+
+        private ContextVersion(int major, int minor) {
+            this.major = major;
+            this.minor = minor;
+        }
+
+        @Override
+        public String toString() {
+            return major + "." + minor;
         }
     }
 

--- a/src/org/lwjgl/opengl/awt/MacOSXGLDataUtil.java
+++ b/src/org/lwjgl/opengl/awt/MacOSXGLDataUtil.java
@@ -61,49 +61,57 @@ final class MacOSXGLDataUtil {
     }
 
     static PixelFormatSelection choosePixelFormat(GLData data, PixelFormatFactory factory) throws AWTException {
-        List<int[]> candidates = createPixelFormatCandidates(data);
-        for (int[] candidate : candidates) {
-            long pixelFormat = factory.create(candidate);
-            if (pixelFormat != 0L) {
-                return new PixelFormatSelection(pixelFormat, candidate);
+        int attempts = 0;
+        for (int profile : profileAttributes(data)) {
+            List<int[]> candidates = createPixelFormatCandidates(data, profile);
+            for (int[] candidate : candidates) {
+                attempts++;
+                long pixelFormat = factory.create(candidate);
+                if (pixelFormat != 0L) {
+                    return new PixelFormatSelection(pixelFormat, candidate);
+                }
             }
         }
         throw new AWTException("No compatible macOS OpenGL pixel format found after "
-                + candidates.size() + " attempts");
+                + attempts + " attempts");
     }
 
     static List<int[]> createPixelFormatCandidates(GLData data) {
+        return createPixelFormatCandidates(data, profileAttribute(data));
+    }
+
+    private static List<int[]> createPixelFormatCandidates(GLData data, int profile) {
         List<int[]> candidates = new ArrayList<>();
         boolean includeSamples = data.samples > 0;
         boolean includeAccumulation = accumulatorSize(data) > 0;
         boolean includeStereo = data.stereo;
         boolean includeFloat = data.pixelFormatFloat;
         candidates.add(createPixelFormatAttributes(data, includeSamples, includeAccumulation,
-                includeStereo, includeFloat, true));
+                includeStereo, includeFloat, true, profile));
 
         // Relax cumulatively from the most to the least exotic attribute. Dropping stereo and floating-point color
         // first preserves commonly supported requests such as multisampling whenever possible.
         if (includeStereo) {
             includeStereo = false;
             candidates.add(createPixelFormatAttributes(data, includeSamples, includeAccumulation,
-                    false, includeFloat, true));
+                    false, includeFloat, true, profile));
         }
         if (includeFloat) {
             includeFloat = false;
             candidates.add(createPixelFormatAttributes(data, includeSamples, includeAccumulation,
-                    includeStereo, false, true));
+                    includeStereo, false, true, profile));
         }
         if (includeAccumulation) {
             includeAccumulation = false;
             candidates.add(createPixelFormatAttributes(data, includeSamples, false,
-                    includeStereo, includeFloat, true));
+                    includeStereo, includeFloat, true, profile));
         }
         if (includeSamples) {
             includeSamples = false;
             candidates.add(createPixelFormatAttributes(data, false, includeAccumulation,
-                    includeStereo, includeFloat, true));
+                    includeStereo, includeFloat, true, profile));
         }
-        candidates.add(createPixelFormatAttributes(data, false, false, false, false, false));
+        candidates.add(createPixelFormatAttributes(data, false, false, false, false, false, profile));
         return candidates;
     }
 
@@ -112,11 +120,12 @@ final class MacOSXGLDataUtil {
                 includeOptional && accumulatorSize(data) > 0,
                 includeOptional && data.stereo,
                 includeOptional && data.pixelFormatFloat,
-                accelerated);
+                accelerated, profileAttribute(data));
     }
 
     private static int[] createPixelFormatAttributes(GLData data, boolean includeSamples,
-            boolean includeAccumulation, boolean includeStereo, boolean includeFloat, boolean accelerated) {
+            boolean includeAccumulation, boolean includeStereo, boolean includeFloat, boolean accelerated,
+            int profile) {
         List<Integer> attributes = new ArrayList<>();
         if (accelerated) {
             attributes.add(NS_OPENGL_PFA_ACCELERATED);
@@ -156,7 +165,7 @@ final class MacOSXGLDataUtil {
             addValue(attributes, NS_OPENGL_PFA_SAMPLES, data.samples);
         }
 
-        addValue(attributes, NS_OPENGL_PFA_OPENGL_PROFILE, profileAttribute(data));
+        addValue(attributes, NS_OPENGL_PFA_OPENGL_PROFILE, profile);
         attributes.add(0);
 
         int[] result = new int[attributes.size()];
@@ -167,13 +176,32 @@ final class MacOSXGLDataUtil {
     }
 
     static int profileAttribute(GLData data) {
+        return profileAttribute(data, data.majorVersion, data.minorVersion);
+    }
+
+    private static List<Integer> profileAttributes(GLData data) {
+        List<Integer> profiles = new ArrayList<>();
+        if (data.versionPolicy == GLData.VersionPolicy.EXACT) {
+            profiles.add(profileAttribute(data));
+            return profiles;
+        }
+        for (GLUtil.ContextVersion version : GLUtil.contextVersionCandidates(data, 4, 1)) {
+            int profile = profileAttribute(data, version.major, version.minor);
+            if (!profiles.contains(profile)) {
+                profiles.add(profile);
+            }
+        }
+        return profiles;
+    }
+
+    private static int profileAttribute(GLData data, int majorVersion, int minorVersion) {
         if (data.profile == GLData.Profile.COMPATIBILITY) {
             return NS_OPENGL_PROFILE_LEGACY;
         }
-        if (data.majorVersion >= 4 || (data.majorVersion == 3 && data.minorVersion > 2)) {
+        if (majorVersion >= 4 || (majorVersion == 3 && minorVersion > 2)) {
             return NS_OPENGL_PROFILE_4_1_CORE;
         }
-        if (data.profile == GLData.Profile.CORE || data.majorVersion >= 3) {
+        if (data.profile == GLData.Profile.CORE || majorVersion >= 3) {
             return NS_OPENGL_PROFILE_3_2_CORE;
         }
         return NS_OPENGL_PROFILE_LEGACY;

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
@@ -25,6 +25,7 @@ import java.awt.AWTException;
 import java.awt.Canvas;
 import java.nio.IntBuffer;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.lwjgl.egl.EGL10.*;
@@ -111,14 +112,40 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
 
         try {
             validateCapabilities(attribs, displayRef.capabilities);
-            long config = chooseConfig(visualID, attribs);
             bindClientAPI(attribs.api);
 
             long shareContext = getShareContext(attribs);
-            eglContext = eglCreateContext(eglDisplay, config, shareContext,
-                    contextAttributes(attribs, displayRef.capabilities));
+            List<GLUtil.ContextVersion> candidates = GLUtil.contextVersionCandidates(attribs,
+                    attribs.api == GLData.API.GLES ? 3 : 4,
+                    attribs.api == GLData.API.GLES ? 2 : 6);
+            long config = 0L;
+            int lastError = EGL_SUCCESS;
+            for (GLUtil.ContextVersion version : candidates) {
+                long candidateConfig = chooseConfig(visualID, attribs, version);
+                if (candidateConfig == 0L) {
+                    if (attribs.versionPolicy == GLData.VersionPolicy.EXACT) {
+                        throw new AWTException("No EGL framebuffer configuration matches the AWT window visual");
+                    }
+                    continue;
+                }
+                eglContext = eglCreateContext(eglDisplay, candidateConfig, shareContext,
+                        contextAttributes(attribs, displayRef.capabilities, version));
+                if (eglContext != EGL_NO_CONTEXT) {
+                    config = candidateConfig;
+                    break;
+                }
+                lastError = eglGetError();
+                if (attribs.versionPolicy == GLData.VersionPolicy.EXACT) {
+                    throw eglFailure("Failed to create EGL context", lastError);
+                }
+            }
             if (eglContext == EGL_NO_CONTEXT) {
-                throw eglFailure("Failed to create EGL context");
+                String message = "Failed to create an EGL context satisfying "
+                        + GLUtil.describeVersionRequest(attribs) + " after " + candidates.size() + " attempts";
+                if (lastError != EGL_SUCCESS) {
+                    throw eglFailure(message, lastError);
+                }
+                throw new AWTException(message);
             }
 
             eglSurface = createWindowSurface(config, drawable, attribs);
@@ -177,6 +204,9 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
         }
 
         boolean createContext = capabilities.EGL15 || capabilities.EGL_KHR_create_context;
+        if (data.versionPolicy != GLData.VersionPolicy.EXACT && !createContext) {
+            throw new AWTException("Context version policies require EGL_KHR_create_context");
+        }
         if (data.api == GLData.API.GL && data.majorVersion > 0 && !createContext) {
             throw new AWTException("Versioned desktop OpenGL contexts require EGL_KHR_create_context");
         }
@@ -197,10 +227,10 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
         }
     }
 
-    private long chooseConfig(long visualID, GLData data) throws AWTException {
+    private long chooseConfig(long visualID, GLData data, GLUtil.ContextVersion version) throws AWTException {
         IntBuffer attributes = BufferUtils.createIntBuffer(40);
         attributes.put(EGL_SURFACE_TYPE).put(EGL_WINDOW_BIT);
-        attributes.put(EGL_RENDERABLE_TYPE).put(renderableType(data));
+        attributes.put(EGL_RENDERABLE_TYPE).put(renderableType(data, version));
         attributes.put(EGL_NATIVE_VISUAL_ID).put((int) visualID);
         attributes.put(EGL_RED_SIZE).put(data.redSize);
         attributes.put(EGL_GREEN_SIZE).put(data.greenSize);
@@ -221,16 +251,19 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
             throw eglFailure("Failed to choose EGL framebuffer configuration");
         }
         if (count.get(0) == 0) {
-            throw new AWTException("No EGL framebuffer configuration matches the AWT window visual");
+            return 0L;
         }
         return configs.get(0);
     }
 
-    private static int renderableType(GLData data) {
+    private static int renderableType(GLData data, GLUtil.ContextVersion version) {
         if (data.api == GLData.API.GL) {
             return EGL_OPENGL_BIT;
         }
-        return data.majorVersion >= 2 ? EGL_OPENGL_ES2_BIT : EGL_OPENGL_ES_BIT;
+        if (version.major >= 3) {
+            return EGL_OPENGL_ES3_BIT_KHR;
+        }
+        return version.major >= 2 ? EGL_OPENGL_ES2_BIT : EGL_OPENGL_ES_BIT;
     }
 
     private static void bindClientAPI(GLData.API api) throws AWTException {
@@ -257,14 +290,15 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
         return data.shareContext.context;
     }
 
-    private static IntBuffer contextAttributes(GLData data, EGLCapabilities capabilities) {
+    private static IntBuffer contextAttributes(GLData data, EGLCapabilities capabilities,
+            GLUtil.ContextVersion version) {
         IntBuffer attributes = BufferUtils.createIntBuffer(32);
         boolean createContext = capabilities.EGL15 || capabilities.EGL_KHR_create_context;
 
         if (createContext) {
-            if (data.majorVersion > 0) {
-                attributes.put(EGL_CONTEXT_MAJOR_VERSION_KHR).put(data.majorVersion);
-                attributes.put(EGL_CONTEXT_MINOR_VERSION_KHR).put(data.minorVersion);
+            if (version.major > 0) {
+                attributes.put(EGL_CONTEXT_MAJOR_VERSION_KHR).put(version.major);
+                attributes.put(EGL_CONTEXT_MINOR_VERSION_KHR).put(version.minor);
             }
 
             int flags = 0;
@@ -292,8 +326,8 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
                                 : EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR);
             }
         } else {
-            if (data.api == GLData.API.GLES && data.majorVersion > 0) {
-                attributes.put(EGL_CONTEXT_CLIENT_VERSION).put(data.majorVersion);
+            if (data.api == GLData.API.GLES && version.major > 0) {
+                attributes.put(EGL_CONTEXT_CLIENT_VERSION).put(version.major);
             }
             if (data.robustness) {
                 attributes.put(EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT).put(EGL_TRUE);
@@ -394,6 +428,7 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
         APIVersion version = APIUtil.apiParseVersion(getString(GL11.GL_VERSION, glGetString));
 
         effective.api = requested.api;
+        effective.versionPolicy = requested.versionPolicy;
         effective.majorVersion = version.major;
         effective.minorVersion = version.minor;
 
@@ -619,7 +654,10 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
     }
 
     private static AWTException eglFailure(String message) {
-        int error = eglGetError();
+        return eglFailure(message, eglGetError());
+    }
+
+    private static AWTException eglFailure(String message, int error) {
         return new AWTException(message + ": " + eglErrorName(error)
                 + " (0x" + Integer.toHexString(error).toUpperCase() + ")");
     }

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -16,6 +16,7 @@ import java.awt.AWTException;
 import java.awt.Canvas;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -30,6 +31,8 @@ import org.lwjgl.opengl.GL32;
 import org.lwjgl.opengl.GL43;
 import org.lwjgl.system.APIUtil.APIVersion;
 import org.lwjgl.system.APIUtil;
+import org.lwjgl.system.Callback;
+import org.lwjgl.system.CallbackI;
 import org.lwjgl.system.Checks;
 import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
@@ -45,6 +48,16 @@ import static org.lwjgl.system.Pointer.POINTER_SIZE;
 
 public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	private static final long X_GET_GEOMETRY = X11.getLibrary().getFunctionAddress("XGetGeometry");
+	private static final long X_SET_ERROR_HANDLER = X11.getLibrary().getFunctionAddress("XSetErrorHandler");
+	private static final long X_SYNC = X11.getLibrary().getFunctionAddress("XSync");
+	private static final Object X_ERROR_HANDLER_LOCK = new Object();
+	private static volatile boolean contextCreationXError;
+	private static final XErrorHandlerI CONTEXT_CREATION_ERROR_HANDLER = (ignoredDisplay, ignoredEvent) -> {
+		contextCreationXError = true;
+		return 0;
+	};
+	private static final long CONTEXT_CREATION_ERROR_HANDLER_ADDRESS =
+			CONTEXT_CREATION_ERROR_HANDLER.address();
 	public static final JAWT awt;
 	static {
 		awt = JAWT.calloc();
@@ -59,6 +72,9 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	private Canvas canvas;
 
 	private long create(int depth, GLData attribs, GLData effective) throws AWTException {
+		if (attribs.versionPolicy != GLData.VersionPolicy.EXACT) {
+			GLUtil.validateVersionAttributes(attribs);
+		}
 		int screen = X11.XDefaultScreen(display);
 		Set<String> extensions = GLXSwapInterval.parseExtensions(
 				glXQueryExtensionsString(display, screen));
@@ -83,8 +99,10 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 		}
 
 		GLXSwapInterval swapInterval = verifyGLXCapabilities(extensions, attribs);
-		IntBuffer gl_attrib_list = bufferGLAttribs(attribs);
-		
+		List<GLUtil.ContextVersion> candidates = GLUtil.contextVersionCandidates(attribs,
+				attribs.api == GLData.API.GLES ? 3 : 4,
+				attribs.api == GLData.API.GLES ? 2 : 6);
+
 		long share_context = NULL;
 		if(Objects.nonNull(attribs.shareContext)) {
 			if(attribs.shareContext.context == NULL){
@@ -94,9 +112,20 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 			share_context = attribs.shareContext.context;
 		}
 		
-		long context = glXCreateContextAttribsARB(display, fbConfigs.get(0), share_context, true, gl_attrib_list);
+		long context = 0L;
+		for (GLUtil.ContextVersion version : candidates) {
+			context = tryCreateContext(fbConfigs.get(0), share_context,
+					bufferGLAttribs(attribs, version));
+			if (context != 0L) {
+				break;
+			}
+		}
 		if (context == 0) {
-			throw new AWTException("Unable to create GLX context");
+			if (attribs.versionPolicy == GLData.VersionPolicy.EXACT) {
+				throw new AWTException("Unable to create GLX context");
+			}
+			throw new AWTException("Unable to create a GLX context satisfying "
+					+ GLUtil.describeVersionRequest(attribs) + " after " + candidates.size() + " attempts");
 		}
 
 		boolean initialized = false;
@@ -111,6 +140,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 			if (swapInterval != null) {
 				swapInterval.apply(display, drawable);
 			}
+			effective.versionPolicy = attribs.versionPolicy;
 			populateEffectiveGLAttribs(effective);
 			initialized = true;
 			return context;
@@ -119,6 +149,31 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 			if (!initialized) {
 				glXDestroyContext(display, context);
 			}
+		}
+	}
+
+	private long tryCreateContext(long fbConfig, long shareContext, IntBuffer attributes) {
+		synchronized (X_ERROR_HANDLER_LOCK) {
+			// Context creation failures are reported as X errors by GLX. Flush older errors before temporarily replacing
+			// AWT's process-wide handler, then synchronize again while our handler is installed.
+			JNI.callPI(display, 0, X_SYNC);
+			contextCreationXError = false;
+			long previousErrorHandler = JNI.callPP(CONTEXT_CREATION_ERROR_HANDLER_ADDRESS, X_SET_ERROR_HANDLER);
+			long context;
+			try {
+				context = glXCreateContextAttribsARB(
+						display, fbConfig, shareContext, true, attributes);
+				JNI.callPI(display, 0, X_SYNC);
+			} finally {
+				JNI.callPP(previousErrorHandler, X_SET_ERROR_HANDLER);
+			}
+			if (contextCreationXError) {
+				if (context != 0L) {
+					glXDestroyContext(display, context);
+				}
+				return 0L;
+			}
+			return context;
 		}
 	}
 
@@ -295,16 +350,16 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 		return GLXSwapInterval.create(data.swapInterval, extensions);
 	}
 
-	private static IntBuffer bufferGLAttribs(GLData data) throws AWTException {
+	private static IntBuffer bufferGLAttribs(GLData data, GLUtil.ContextVersion version) throws AWTException {
 		IntBuffer gl_attrib_list = BufferUtils.createIntBuffer(16 * 2);
 
 		// Set the render type and version
 		gl_attrib_list.put(GLX_RENDER_TYPE).put(GLX_RGBA_TYPE);
 
-		if (data.majorVersion > 0) {
+		if (version.major > 0) {
 			gl_attrib_list
-				.put(GLX_CONTEXT_MAJOR_VERSION_ARB).put(data.majorVersion)
-				.put(GLX_CONTEXT_MINOR_VERSION_ARB).put(data.minorVersion);
+				.put(GLX_CONTEXT_MAJOR_VERSION_ARB).put(version.major)
+				.put(GLX_CONTEXT_MINOR_VERSION_ARB).put(version.minor);
 		}
 
 		// Set the profile based on GLData.api and GLData.profile
@@ -442,5 +497,29 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 
 	private static String getString(int pname, long function) {
 		return memUTF8(Checks.check(JNI.callP(pname, function)));
+	}
+
+	@FunctionalInterface
+	private interface XErrorHandlerI extends CallbackI {
+		Callback.Descriptor DESCRIPTOR = new Callback.Descriptor(
+				XErrorHandlerI.class,
+				java.lang.invoke.MethodHandles.lookup(),
+				APIUtil.apiCreateCIF(FFI_DEFAULT_ABI, ffi_type_sint32,
+						ffi_type_pointer, ffi_type_pointer));
+
+		@Override
+		default Callback.Descriptor getDescriptor() {
+			return DESCRIPTOR;
+		}
+
+		@Override
+		default void callback(long returnValue, long arguments) {
+			int result = invoke(
+					memGetAddress(arguments),
+					memGetAddress(arguments + POINTER_SIZE));
+			memPutInt(returnValue, result);
+		}
+
+		int invoke(long display, long event);
 	}
 }

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -136,6 +136,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                             }
                             this.context = context;
                             configureSwapInterval(context, attribs.swapInterval);
+                            effective.versionPolicy = attribs.versionPolicy;
                             populateEffectiveData(context, effective);
                             this.doubleBuffered = effective.doubleBuffer;
                         } finally {

--- a/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformWin32GLCanvas.java
@@ -5,6 +5,7 @@ import org.lwjgl.opengl.GL;
 import org.lwjgl.opengl.awt.GLData.API;
 import org.lwjgl.opengl.awt.GLData.Profile;
 import org.lwjgl.opengl.awt.GLData.ReleaseBehavior;
+import org.lwjgl.opengl.awt.GLData.VersionPolicy;
 import org.lwjgl.system.Checks;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
@@ -22,6 +23,7 @@ import java.awt.Canvas;
 import java.nio.IntBuffer;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.lwjgl.opengl.ARBMultisample.GL_SAMPLES_ARB;
@@ -237,7 +239,8 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
             }
 
             Set<String> wglExtensions = queryWGLExtensions(hDCdummy);
-            boolean legacyContext = !atLeast30(attribs.majorVersion, attribs.minorVersion)
+            boolean legacyContext = attribs.versionPolicy == VersionPolicy.EXACT
+                    && !atLeast30(attribs.majorVersion, attribs.minorVersion)
                     && attribs.samples == 0
                     && !attribs.sRGB
                     && !attribs.pixelFormatFloat
@@ -397,11 +400,54 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
             readExtendedPixelFormat(hDC, pixelFormat, attribList, attribListAddr, effective);
         }
 
-        attribList.rewind();
-        if (attribs.api == API.GL && atLeast30(attribs.majorVersion, attribs.minorVersion)
-                || attribs.api == API.GLES && attribs.majorVersion > 0) {
-            attribList.put(WGL_CONTEXT_MAJOR_VERSION_ARB).put(attribs.majorVersion);
-            attribList.put(WGL_CONTEXT_MINOR_VERSION_ARB).put(attribs.minorVersion);
+        List<ContextVersion> candidates = contextVersionCandidates(attribs,
+                attribs.api == API.GLES ? 3 : 4, attribs.api == API.GLES ? 2 : 6);
+        applyPixelFormat(hDC, pixelFormat);
+        long context = 0L;
+        for (ContextVersion version : candidates) {
+            encodeContextAttributes(attribList, attribs, version, wglExtensions);
+            context = callPPPP(hDC,
+                    attribs.shareContext != null ? attribs.shareContext.context : 0L,
+                    attribListAddr, createContextAttribs);
+            if (context != 0L) {
+                break;
+            }
+        }
+        if (context == 0L) {
+            if (attribs.versionPolicy == VersionPolicy.EXACT) {
+                throw new AWTException("Failed to create OpenGL context.");
+            }
+            throw new AWTException("Failed to create a context satisfying "
+                    + describeVersionRequest(attribs) + " after " + candidates.size() + " attempts");
+        }
+
+        boolean success = false;
+        try {
+            if (!wglMakeCurrent(null, hDC, context)) {
+                throw new AWTException("Could not make GL context current");
+            }
+            configureSwapInterval(attribs, wglExtensions);
+            configureSwapGroup(attribs, wglExtensions, bufferAddr, hDC);
+            readEffectiveContext(attribs, effective, wglExtensions, bufferAddr);
+            success = true;
+            return context;
+        } finally {
+            if (!success) {
+                wglMakeCurrent(null, 0L, 0L);
+                wglDeleteContext(null, context);
+            }
+        }
+    }
+
+    private static void encodeContextAttributes(IntBuffer attribList, GLData attribs,
+            ContextVersion version, Set<String> wglExtensions) throws AWTException {
+        attribList.clear();
+        boolean specifyVersion = attribs.versionPolicy != VersionPolicy.EXACT
+                || attribs.api == API.GL && atLeast30(version.major, version.minor)
+                || attribs.api == API.GLES && version.major > 0;
+        if (specifyVersion) {
+            attribList.put(WGL_CONTEXT_MAJOR_VERSION_ARB).put(version.major);
+            attribList.put(WGL_CONTEXT_MINOR_VERSION_ARB).put(version.minor);
         }
         int profile = 0;
         if (attribs.api == API.GL) {
@@ -460,32 +506,7 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
                         .put(WGL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB);
             }
         }
-        attribList.put(0).put(0);
-
-        applyPixelFormat(hDC, pixelFormat);
-        long context = callPPPP(hDC,
-                attribs.shareContext != null ? attribs.shareContext.context : 0L,
-                attribListAddr, createContextAttribs);
-        if (context == 0L) {
-            throw new AWTException("Failed to create OpenGL context.");
-        }
-
-        boolean success = false;
-        try {
-            if (!wglMakeCurrent(null, hDC, context)) {
-                throw new AWTException("Could not make GL context current");
-            }
-            configureSwapInterval(attribs, wglExtensions);
-            configureSwapGroup(attribs, wglExtensions, bufferAddr, hDC);
-            readEffectiveContext(attribs, effective, wglExtensions, bufferAddr);
-            success = true;
-            return context;
-        } finally {
-            if (!success) {
-                wglMakeCurrent(null, 0L, 0L);
-                wglDeleteContext(null, context);
-            }
-        }
+        attribList.put(0).flip();
     }
 
     private static void readExtendedPixelFormat(long hDC, int pixelFormat, IntBuffer attribList,
@@ -567,7 +588,12 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
         long getInteger = GL.getFunctionProvider().getFunctionAddress("glGetIntegerv");
         long getString = GL.getFunctionProvider().getFunctionAddress("glGetString");
         effective.api = attribs.api;
-        if (atLeast30(attribs.majorVersion, attribs.minorVersion)) {
+        effective.versionPolicy = attribs.versionPolicy;
+        APIVersion version = apiParseVersion(
+                memUTF8(Checks.check(callP(GL_VERSION, getString))));
+        effective.majorVersion = version.major;
+        effective.minorVersion = version.minor;
+        if (atLeast30(effective.majorVersion, effective.minorVersion)) {
             callPV(GL_MAJOR_VERSION, bufferAddr, getInteger);
             effective.majorVersion = memGetInt(bufferAddr);
             callPV(GL_MINOR_VERSION, bufferAddr, getInteger);
@@ -577,11 +603,6 @@ public class PlatformWin32GLCanvas implements PlatformGLCanvas {
             effective.debug = (effectiveContextFlags & GL_CONTEXT_FLAG_DEBUG_BIT) != 0;
             effective.forwardCompatible = (effectiveContextFlags & GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT) != 0;
             effective.robustness = (effectiveContextFlags & GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB) != 0;
-        } else {
-            APIVersion version = apiParseVersion(
-                    memUTF8(Checks.check(callP(GL_VERSION, getString))));
-            effective.majorVersion = version.major;
-            effective.minorVersion = version.minor;
         }
         if (attribs.api == API.GL && atLeast32(effective.majorVersion, effective.minorVersion)) {
             callPV(GL_CONTEXT_PROFILE_MASK, bufferAddr, getInteger);

--- a/test/org/lwjgl/opengl/awt/GLUtilTest.java
+++ b/test/org/lwjgl/opengl/awt/GLUtilTest.java
@@ -1,0 +1,101 @@
+package org.lwjgl.opengl.awt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GLUtilTest {
+
+    @Test
+    void exactPreservesTheConfiguredSingleRequest() {
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 3;
+
+        assertEquals(Arrays.asList("3.3"), candidates(data, 4, 6));
+    }
+
+    @Test
+    void atLeastTriesCoreVersionsFromThePlatformMaximumToTheMinimum() {
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 3;
+        data.profile = GLData.Profile.CORE;
+        data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
+
+        assertEquals(Arrays.asList("4.6", "4.5", "4.4", "4.3", "4.2", "4.1", "4.0", "3.3"),
+                candidates(data, 4, 6));
+    }
+
+    @Test
+    void highestHonorsThePlatformMaximumAndProfile() {
+        GLData data = new GLData();
+        data.profile = GLData.Profile.CORE;
+        data.versionPolicy = GLData.VersionPolicy.HIGHEST;
+
+        assertEquals(Arrays.asList("4.1", "4.0", "3.3", "3.2"), candidates(data, 4, 1));
+    }
+
+    @Test
+    void atLeastEnumeratesOpenGLESVersionsSeparately() {
+        GLData data = new GLData();
+        data.api = GLData.API.GLES;
+        data.majorVersion = 2;
+        data.minorVersion = 0;
+        data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
+
+        assertEquals(Arrays.asList("3.2", "3.1", "3.0", "2.0"), candidates(data, 3, 2));
+    }
+
+    @Test
+    void highestAllowsAProfileWithoutAConfiguredVersion() {
+        GLData data = new GLData();
+        data.profile = GLData.Profile.CORE;
+        data.versionPolicy = GLData.VersionPolicy.HIGHEST;
+
+        GLUtil.validateAttributes(data);
+    }
+
+    @Test
+    void atLeastRequiresAValidMinimum() {
+        GLData data = new GLData();
+        data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
+
+        assertThrows(IllegalArgumentException.class, () -> GLUtil.validateAttributes(data));
+    }
+
+    @Test
+    void highestIgnoresAConfiguredVersion() {
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 3;
+        data.versionPolicy = GLData.VersionPolicy.HIGHEST;
+
+        GLUtil.validateAttributes(data);
+        assertEquals("4.6", GLUtil.contextVersionCandidates(data, 4, 6).get(0).toString());
+    }
+
+    @Test
+    void recognizesTheCurrentDesktopAndEmbeddedVersionCeilings() {
+        assertTrue(GLUtil.validVersionGL(4, 6));
+        assertFalse(GLUtil.validVersionGL(5, 0));
+        assertTrue(GLUtil.validVersionGLES(3, 2));
+        assertFalse(GLUtil.validVersionGLES(3, 3));
+    }
+
+    private static List<String> candidates(GLData data, int maximumMajor, int maximumMinor) {
+        List<String> versions = new ArrayList<>();
+        for (GLUtil.ContextVersion version :
+                GLUtil.contextVersionCandidates(data, maximumMajor, maximumMinor)) {
+            versions.add(version.toString());
+        }
+        return versions;
+    }
+}

--- a/test/org/lwjgl/opengl/awt/LinuxEGLCanvasIntegrationTest.java
+++ b/test/org/lwjgl/opengl/awt/LinuxEGLCanvasIntegrationTest.java
@@ -75,13 +75,14 @@ class LinuxEGLCanvasIntegrationTest {
     }
 
     @Test
-    void honorsCoreProfileContextAttributes() throws Exception {
+    void selectsAnAtLeastCoreProfileContext() throws Exception {
         assumeEGLIsSelected();
 
         GLData data = new GLData();
         data.majorVersion = 3;
         data.minorVersion = 2;
         data.profile = GLData.Profile.CORE;
+        data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
         data.swapInterval = 0;
 
         AtomicReference<JFrame> frameRef = new AtomicReference<>();
@@ -97,6 +98,7 @@ class LinuxEGLCanvasIntegrationTest {
                 assertTrue(GLUtil.atLeast32(
                         canvas.effective.majorVersion, canvas.effective.minorVersion));
                 assertEquals(GLData.Profile.CORE, canvas.effective.profile);
+                assertEquals(GLData.VersionPolicy.AT_LEAST, canvas.effective.versionPolicy);
                 assertEquals(Integer.valueOf(0), canvas.effective.swapInterval);
             });
         } finally {

--- a/test/org/lwjgl/opengl/awt/LinuxGLXCanvasIntegrationTest.java
+++ b/test/org/lwjgl/opengl/awt/LinuxGLXCanvasIntegrationTest.java
@@ -11,12 +11,59 @@ import javax.swing.SwingUtilities;
 import java.awt.Dimension;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @EnabledOnOs(OS.LINUX)
 class LinuxGLXCanvasIntegrationTest {
+    @Test
+    void selectsAnAtLeastCoreProfileContext() throws Exception {
+        assumeGLXIsSelected();
+
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 2;
+        data.profile = GLData.Profile.CORE;
+        data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
+
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+        AtomicReference<TestCanvas> canvasRef = new AtomicReference<>();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = new TestCanvas(data);
+                canvas.setPreferredSize(new Dimension(320, 240));
+
+                JFrame frame = new JFrame("Linux GLX context version policy test");
+                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                frame.getContentPane().add(canvas);
+                frame.pack();
+                frame.setVisible(true);
+                frameRef.set(frame);
+                canvasRef.set(canvas);
+            });
+
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = canvasRef.get();
+                canvas.render();
+                assertTrue(canvas.platformCanvas instanceof PlatformLinuxGLCanvas);
+                assertTrue(GLUtil.atLeast32(
+                        canvas.effective.majorVersion, canvas.effective.minorVersion));
+                assertEquals(GLData.Profile.CORE, canvas.effective.profile);
+                assertEquals(GLData.VersionPolicy.AT_LEAST, canvas.effective.versionPolicy);
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                GL.setCapabilities(null);
+                JFrame frame = frameRef.get();
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
     @Test
     void honorsMultisampleFramebufferAttributes() throws Exception {
         assumeGLXIsSelected();

--- a/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
@@ -175,6 +175,7 @@ class MacOSXGLCanvasLifecycleTest {
         data.majorVersion = 3;
         data.minorVersion = 2;
         data.profile = GLData.Profile.CORE;
+        data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
         data.doubleBuffer = true;
         data.swapInterval = 0;
         data.stencilSize = 8;
@@ -186,6 +187,7 @@ class MacOSXGLCanvasLifecycleTest {
             assertEquals(0, canvas.configuredSwapInterval);
             assertEquals(Integer.valueOf(0), canvas.effective.swapInterval);
             assertEquals(GLData.API.GL, canvas.effective.api);
+            assertEquals(GLData.VersionPolicy.AT_LEAST, canvas.effective.versionPolicy);
             assertEquals(GLData.Profile.CORE, canvas.effective.profile);
             assertEquals(canvas.actualMajorVersion, canvas.effective.majorVersion);
             assertEquals(canvas.actualMinorVersion, canvas.effective.minorVersion);

--- a/test/org/lwjgl/opengl/awt/MacOSXGLDataUtilTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLDataUtilTest.java
@@ -24,6 +24,7 @@ import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_SAMPLE_BUFFERS
 import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_SAMPLES;
 import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_STENCIL_SIZE;
 import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PFA_STEREO;
+import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PROFILE_3_2_CORE;
 import static org.lwjgl.opengl.awt.MacOSXGLDataUtil.NS_OPENGL_PROFILE_4_1_CORE;
 
 class MacOSXGLDataUtilTest {
@@ -118,6 +119,28 @@ class MacOSXGLDataUtilTest {
         data.profile = GLData.Profile.CORE;
 
         assertEquals(NS_OPENGL_PROFILE_4_1_CORE, MacOSXGLDataUtil.profileAttribute(data));
+    }
+
+    @Test
+    void atLeastFallsBackFromTheHighestMacOSCoreProfile() throws Exception {
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 2;
+        data.profile = GLData.Profile.CORE;
+        data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
+        List<int[]> attempts = new ArrayList<>();
+
+        MacOSXGLDataUtil.PixelFormatSelection selection = MacOSXGLDataUtil.choosePixelFormat(data, attributes -> {
+            attempts.add(attributes);
+            return containsPair(attributes, NS_OPENGL_PFA_OPENGL_PROFILE, NS_OPENGL_PROFILE_3_2_CORE)
+                    ? 42L : 0L;
+        });
+
+        assertEquals(42L, selection.pixelFormat);
+        assertEquals(3, attempts.size());
+        assertTrue(containsPair(attempts.get(0), NS_OPENGL_PFA_OPENGL_PROFILE, NS_OPENGL_PROFILE_4_1_CORE));
+        assertTrue(containsPair(attempts.get(1), NS_OPENGL_PFA_OPENGL_PROFILE, NS_OPENGL_PROFILE_4_1_CORE));
+        assertTrue(containsPair(attempts.get(2), NS_OPENGL_PFA_OPENGL_PROFILE, NS_OPENGL_PROFILE_3_2_CORE));
     }
 
     @Test

--- a/test/org/lwjgl/opengl/awt/Win32JAWTDrawingSurfaceLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/Win32JAWTDrawingSurfaceLifecycleTest.java
@@ -48,6 +48,7 @@ class Win32JAWTDrawingSurfaceLifecycleTest {
             data.majorVersion = 3;
             data.minorVersion = 2;
             data.profile = GLData.Profile.CORE;
+            data.versionPolicy = GLData.VersionPolicy.AT_LEAST;
             data.samples = samples;
             data.swapInterval = 0;
 
@@ -92,6 +93,10 @@ class Win32JAWTDrawingSurfaceLifecycleTest {
                     "The created context does not use the requested sample count");
             assertEquals(samples == 0 ? 0 : 1, canvasRef.get().effective.sampleBuffers,
                     "The created context reports an unexpected sample-buffer count");
+            assertTrue(GLUtil.atLeast32(canvasRef.get().effective.majorVersion,
+                    canvasRef.get().effective.minorVersion));
+            assertEquals(GLData.Profile.CORE, canvasRef.get().effective.profile);
+            assertEquals(GLData.VersionPolicy.AT_LEAST, canvasRef.get().effective.versionPolicy);
             int gdiObjectsBefore = getGdiObjectCount();
 
             renderResizeCycles(frameRef.get(), canvasRef.get(), MEASURED_CYCLES);


### PR DESCRIPTION
`GLData` currently treats `majorVersion` and `minorVersion` as a single context request. This prevents an application that requires OpenGL 3.3 from receiving OpenGL 4.6 when it is available, limiting its ability to use newer optional functionality. This fixes #58 without changing existing behavior.

This adds `VersionPolicy.EXACT`, `AT_LEAST`, and `HIGHEST`. `EXACT` remains the default. `AT_LEAST` tries profile-compatible versions from the platform ceiling down to the configured minimum, while `HIGHEST` ignores the configured version and has no minimum. The version actually created is reported through `effective.majorVersion` and `effective.minorVersion`.

The selection is implemented for WGL, GLX, EGL, and macOS. GLX context errors are captured during failed attempts so fallback can continue safely. The behavior follows the native context-creation mechanisms described by [WGL_ARB_create_context](https://registry.khronos.org/OpenGL/extensions/ARB/WGL_ARB_create_context.txt), [GLX_ARB_create_context](https://registry.khronos.org/OpenGL/extensions/ARB/GLX_ARB_create_context.txt), and [EGL_KHR_create_context](https://registry.khronos.org/EGL/extensions/KHR/EGL_KHR_create_context.txt).

Tests cover candidate ordering, profile filtering, validation, macOS profile fallback, and real context creation paths across the supported platforms. The README now includes an `AT_LEAST` example.

Fixes #58.