### PR TITLE
Improve LWJGL version-mismatch diagnostics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
 		<resources>
 			<resource>
 				<directory>res</directory>
+				<filtering>true</filtering>
 			</resource>
 			<resource>
 				<directory>native/macosx</directory>
@@ -286,6 +287,9 @@
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>${maven-resources-plugin.version}</version>
+				<configuration>
+					<propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
+				</configuration>
 				<executions>
 					<execution>
 						<id>copy-resources</id>
@@ -346,6 +350,8 @@
 						<manifestEntries>
 							<!-- Add Git commit hash -->
 							<Implementation-Build>${buildNumber}</Implementation-Build>
+							<!-- Record the LWJGL ABI used to compile this artifact. -->
+							<LWJGL-Version>${lwjgl.version}</LWJGL-Version>
 						</manifestEntries>
 					</archive>
 				</configuration>

--- a/res/META-INF/lwjgl3-awt.properties
+++ b/res/META-INF/lwjgl3-awt.properties
@@ -1,0 +1,2 @@
+lwjgl3-awt.version=${project.version}
+lwjgl.version=${lwjgl.version}

--- a/src/org/lwjgl/awt/AWT.java
+++ b/src/org/lwjgl/awt/AWT.java
@@ -1,5 +1,6 @@
 package org.lwjgl.awt;
 
+import org.lwjgl.awt.internal.LWJGLVersionChecker;
 import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.Platform;
 import org.lwjgl.system.jawt.JAWT;
@@ -36,6 +37,9 @@ import static org.lwjgl.system.jawt.JAWTFunctions.*;
  * @author Kai Burjack
  */
 public class AWT implements AutoCloseable {
+	static {
+		LWJGLVersionChecker.check();
+	}
 
 	/**
 	 * Native JAWT object.

--- a/src/org/lwjgl/awt/internal/LWJGLVersionChecker.java
+++ b/src/org/lwjgl/awt/internal/LWJGLVersionChecker.java
@@ -1,0 +1,151 @@
+package org.lwjgl.awt.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Internal runtime dependency diagnostic. This class is public only so lwjgl3-awt entry points in sibling packages
+ * can trigger the check; it is not part of the supported API.
+ */
+public final class LWJGLVersionChecker {
+    private static final String METADATA_RESOURCE = "/META-INF/lwjgl3-awt.properties";
+    private static final Module[] MODULES = {
+            new Module("lwjgl", "org.lwjgl.Version"),
+            new Module("lwjgl-jawt", "org.lwjgl.system.jawt.JAWT"),
+            new Module("lwjgl-egl", "org.lwjgl.egl.EGL"),
+            new Module("lwjgl-opengl", "org.lwjgl.opengl.GL"),
+            new Module("lwjgl-vulkan", "org.lwjgl.vulkan.VK")
+    };
+    private static final boolean INITIALIZED = initialize();
+
+    private LWJGLVersionChecker() {
+    }
+
+    /**
+     * Triggers the one-time runtime dependency check.
+     */
+    public static void check() {
+        if (!INITIALIZED) {
+            throw new AssertionError("LWJGL version check did not initialize");
+        }
+    }
+
+    private static boolean initialize() {
+        try {
+            BuildMetadata metadata = loadBuildMetadata();
+            if (metadata != null && isResolvedVersion(metadata.lwjglVersion)) {
+                warnIfIncompatible(metadata, resolveModules(LWJGLVersionChecker.class.getClassLoader()), System.err);
+            }
+        } catch (RuntimeException | LinkageError ignored) {
+            // Diagnostics must never prevent the library from starting.
+        }
+        return true;
+    }
+
+    static BuildMetadata loadBuildMetadata() {
+        try (InputStream input = LWJGLVersionChecker.class.getResourceAsStream(METADATA_RESOURCE)) {
+            if (input == null) {
+                return null;
+            }
+            Properties properties = new Properties();
+            properties.load(input);
+            return new BuildMetadata(
+                    properties.getProperty("lwjgl3-awt.version"),
+                    properties.getProperty("lwjgl.version"));
+        } catch (IOException | SecurityException ignored) {
+            return null;
+        }
+    }
+
+    static List<ModuleVersion> resolveModules(ClassLoader classLoader) {
+        List<ModuleVersion> versions = new ArrayList<>();
+        for (Module module : MODULES) {
+            ModuleVersion version = resolveModule(classLoader, module);
+            if (version != null) {
+                versions.add(version);
+            }
+        }
+        return versions;
+    }
+
+    private static ModuleVersion resolveModule(ClassLoader classLoader, Module module) {
+        try {
+            Class<?> moduleClass = Class.forName(module.className, false, classLoader);
+            Package modulePackage = moduleClass.getPackage();
+            if (modulePackage == null) {
+                return null;
+            }
+            String version = modulePackage.getSpecificationVersion();
+            return isResolvedVersion(version) ? new ModuleVersion(module.name, version) : null;
+        } catch (ClassNotFoundException | LinkageError | SecurityException ignored) {
+            return null;
+        }
+    }
+
+    static boolean warnIfIncompatible(BuildMetadata metadata, List<ModuleVersion> modules, PrintStream output) {
+        List<ModuleVersion> mismatches = new ArrayList<>();
+        for (ModuleVersion module : modules) {
+            if (!metadata.lwjglVersion.equals(module.version)) {
+                mismatches.add(module);
+            }
+        }
+        if (mismatches.isEmpty()) {
+            return false;
+        }
+
+        String libraryVersion = isResolvedVersion(metadata.libraryVersion)
+                ? metadata.libraryVersion
+                : "unknown";
+        StringBuilder warning = new StringBuilder(384);
+        warning.append("[LWJGLX] [WARN] Incompatible LWJGL module versions detected.\n")
+                .append("lwjgl3-awt ").append(libraryVersion)
+                .append(" was compiled against LWJGL ").append(metadata.lwjglVersion)
+                .append(", but the runtime provides:\n");
+        for (ModuleVersion mismatch : mismatches) {
+            warning.append("  ").append(mismatch.name).append(": ").append(mismatch.version).append('\n');
+        }
+        warning.append("Use one LWJGL version for all org.lwjgl modules and a lwjgl3-awt build compiled against that ")
+                .append("version (the LWJGL BOM can align Maven or Gradle dependencies). Otherwise binary linkage ")
+                .append("errors such as NoSuchMethodError may occur.\n");
+        output.print(warning);
+        return true;
+    }
+
+    private static boolean isResolvedVersion(String version) {
+        return version != null && !version.isEmpty() && version.indexOf("${") < 0;
+    }
+
+    static final class BuildMetadata {
+        final String libraryVersion;
+        final String lwjglVersion;
+
+        BuildMetadata(String libraryVersion, String lwjglVersion) {
+            this.libraryVersion = libraryVersion;
+            this.lwjglVersion = lwjglVersion;
+        }
+    }
+
+    static final class ModuleVersion {
+        final String name;
+        final String version;
+
+        ModuleVersion(String name, String version) {
+            this.name = name;
+            this.version = version;
+        }
+    }
+
+    private static final class Module {
+        final String name;
+        final String className;
+
+        Module(String name, String className) {
+            this.name = name;
+            this.className = className;
+        }
+    }
+}

--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -1,5 +1,6 @@
 package org.lwjgl.opengl.awt;
 
+import org.lwjgl.awt.internal.LWJGLVersionChecker;
 import org.lwjgl.awthacks.NonClearGraphics;
 import org.lwjgl.awthacks.NonClearGraphics2D;
 import org.lwjgl.system.Platform;
@@ -22,6 +23,10 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public abstract class AWTGLCanvas extends Canvas {
     private static final long serialVersionUID = 1L;
+    static {
+        LWJGLVersionChecker.check();
+    }
+
     protected PlatformGLCanvas platformCanvas = createPlatformCanvas();
 
     private static PlatformGLCanvas createPlatformCanvas() {

--- a/src/org/lwjgl/vulkan/awt/AWTVK.java
+++ b/src/org/lwjgl/vulkan/awt/AWTVK.java
@@ -1,5 +1,6 @@
 package org.lwjgl.vulkan.awt;
 
+import org.lwjgl.awt.internal.LWJGLVersionChecker;
 import org.lwjgl.system.Platform;
 import org.lwjgl.vulkan.VkInstance;
 import org.lwjgl.vulkan.VkPhysicalDevice;
@@ -14,6 +15,9 @@ import java.awt.Canvas;
  * and {@link #getSurfaceExtensionName()} must be enabled extensions.
  */
 public class AWTVK {
+	static {
+		LWJGLVersionChecker.check();
+	}
 
 	/**
 	 * Gets the required instance extension for the particular platform.

--- a/src/org/lwjgl/vulkan/awt/AWTVKCanvas.java
+++ b/src/org/lwjgl/vulkan/awt/AWTVKCanvas.java
@@ -1,5 +1,6 @@
 package org.lwjgl.vulkan.awt;
 
+import org.lwjgl.awt.internal.LWJGLVersionChecker;
 import org.lwjgl.system.Platform;
 import org.lwjgl.vulkan.VkInstance;
 import org.lwjgl.vulkan.VkPhysicalDevice;
@@ -24,6 +25,7 @@ public abstract class AWTVKCanvas extends Canvas {
     private static final long serialVersionUID = 1L;
     private static final PlatformVKCanvas platformCanvas;
     static {
+        LWJGLVersionChecker.check();
         // Enhanced switch would work better :(
         switch (Platform.get()) {
         case WINDOWS:

--- a/test/org/lwjgl/awt/internal/LWJGLVersionCheckerTest.java
+++ b/test/org/lwjgl/awt/internal/LWJGLVersionCheckerTest.java
@@ -1,0 +1,82 @@
+package org.lwjgl.awt.internal;
+
+import org.junit.jupiter.api.Test;
+import org.lwjgl.Version;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LWJGLVersionCheckerTest {
+    @Test
+    void buildMetadataContainsExpectedLwjglVersion() {
+        LWJGLVersionChecker.BuildMetadata metadata = LWJGLVersionChecker.loadBuildMetadata();
+
+        assertNotNull(metadata);
+        assertNotNull(metadata.libraryVersion);
+        assertFalse(metadata.libraryVersion.contains("${"));
+        assertEquals(Version.class.getPackage().getSpecificationVersion(), metadata.lwjglVersion);
+    }
+
+    @Test
+    void resolvedLwjglModulesMatchBuildMetadata() {
+        LWJGLVersionChecker.BuildMetadata metadata = LWJGLVersionChecker.loadBuildMetadata();
+        List<LWJGLVersionChecker.ModuleVersion> modules =
+                LWJGLVersionChecker.resolveModules(LWJGLVersionChecker.class.getClassLoader());
+
+        assertNotNull(metadata);
+        assertFalse(modules.isEmpty());
+        for (LWJGLVersionChecker.ModuleVersion module : modules) {
+            assertEquals(metadata.lwjglVersion, module.version, module.name);
+        }
+    }
+
+    @Test
+    void warningIdentifiesMismatchedModulesAndLikelyFailure() throws Exception {
+        LWJGLVersionChecker.BuildMetadata metadata =
+                new LWJGLVersionChecker.BuildMetadata("0.1.8", "3.3.3");
+        List<LWJGLVersionChecker.ModuleVersion> modules = Arrays.asList(
+                new LWJGLVersionChecker.ModuleVersion("lwjgl", "3.3.6"),
+                new LWJGLVersionChecker.ModuleVersion("lwjgl-jawt", "3.3.6"),
+                new LWJGLVersionChecker.ModuleVersion("lwjgl-opengl", "3.3.3"));
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        boolean warned;
+        try (PrintStream output = new PrintStream(bytes, true, "UTF-8")) {
+            warned = LWJGLVersionChecker.warnIfIncompatible(metadata, modules, output);
+        }
+        String warning = bytes.toString("UTF-8");
+
+        assertTrue(warned);
+        assertTrue(warning.contains("lwjgl3-awt 0.1.8 was compiled against LWJGL 3.3.3"));
+        assertTrue(warning.contains("lwjgl: 3.3.6"));
+        assertTrue(warning.contains("lwjgl-jawt: 3.3.6"));
+        assertFalse(warning.contains("lwjgl-opengl: 3.3.3"));
+        assertTrue(warning.contains("LWJGL BOM"));
+        assertTrue(warning.contains("NoSuchMethodError"));
+    }
+
+    @Test
+    void compatibleModulesDoNotProduceAWarning() throws Exception {
+        LWJGLVersionChecker.BuildMetadata metadata =
+                new LWJGLVersionChecker.BuildMetadata("0.2.5", "3.4.2");
+        List<LWJGLVersionChecker.ModuleVersion> modules = Arrays.asList(
+                new LWJGLVersionChecker.ModuleVersion("lwjgl", "3.4.2"),
+                new LWJGLVersionChecker.ModuleVersion("lwjgl-opengl", "3.4.2"));
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        boolean warned;
+        try (PrintStream output = new PrintStream(bytes, true, "UTF-8")) {
+            warned = LWJGLVersionChecker.warnIfIncompatible(metadata, modules, output);
+        }
+
+        assertFalse(warned);
+        assertEquals("", bytes.toString("UTF-8"));
+    }
+}


### PR DESCRIPTION
`lwjgl3-awt` is compiled against a specific LWJGL release, but consuming builds can resolve a different release for one or more `org.lwjgl` modules. Binary API changes can then cause an opaque `NoSuchMethodError` inside a platform backend. This happened in [this external report](https://stackoverflow.com/questions/79536402/lwjgl-awtglcanvas-render-causes-java-lang-nosuchmethoderror), where `lwjgl3-awt` 0.1.8 was combined with LWJGL 3.3.6.

This records the expected LWJGL version in the JAR manifest and `META-INF/lwjgl3-awt.properties`. On first use of an AWT, OpenGL, or Vulkan entry point, a one-time check compares that version with the resolved core, JAWT, EGL, OpenGL, and Vulkan modules without initializing them.

When versions differ, a non-fatal warning identifies the `lwjgl3-awt` version, its expected LWJGL version, and every mismatched runtime module. It also recommends aligning dependencies with a single version, such as through the [LWJGL BOM](https://central.sonatype.com/artifact/org.lwjgl/lwjgl-bom). Compatible modules produce no output, missing optional or unversioned modules are ignored, and the diagnostic itself never prevents startup.

Tests cover the packaged metadata, resolved module versions, mismatch reporting, and the no-warning path for compatible modules.