### PR TITLE
Use the canvas showing state for its macOS layer

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -81,7 +81,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
                     // if the canvas, or a parent component is hidden/shown, we must update the hidden state of the layer
                     if (view != 0L && (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) > 0) {
                         long layer = invokePPP(view, sel_getUid("layer"), objc_msgSend);
-                        setLayerHiddenOnMainThread(layer, !e.getChanged().isShowing());
+                        setLayerHiddenOnMainThread(layer, !canvas.isShowing());
                     }
                 });
                 hierarchyListenerAdded = true;


### PR DESCRIPTION
Related to #144.                                                                                                                                     

The macOS hierarchy listener currently derives the OpenGL layer’s hidden state from `event.getChanged().isShowing()`. However, `HierarchyEvent.getChanged()` returns the component at the top of the hierarchy that changed, which may be an ancestor rather than the canvas.

The `SHOWING_CHANGED` documentation specifically says to use `Component.isShowing()` to determine the hierarchy’s current showing state. [HierarchyEvent documentatio](https://docs.oracle.com/javase/8/docs/api/java/awt/event/HierarchyEvent.html#SHOWING_CHANGED), [Component.isShowing documentation](https://docs.oracle.com/javase/8/docs/api/java/awt/Component.html#isShowing--).                                                                                                                             

This PR therefore uses `canvas.isShowing()` when updating the canvas layer. It is a standalone correctness fix and does not otherwise change rendering or presentation sequencing.