### PR TITLE
Null-return graphics if super graphics not yet initialized

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -320,7 +320,10 @@ public abstract class AWTGLCanvas extends Canvas {
     @Override
     public Graphics getGraphics() {
     	Graphics graphics = super.getGraphics();
-    	return (graphics instanceof Graphics2D) ? 
+    	if (graphics == null) {
+    		return null;
+    	}
+    	return (graphics instanceof Graphics2D) ?
     			new NonClearGraphics2D((Graphics2D) graphics) : new NonClearGraphics(graphics);
     }
 


### PR DESCRIPTION
This is a minor code cleanup. `AWTGLCanvas.getGraphics()` now returns null immediately when `super.getGraphics()` returns null (which happens when the canvas isn't displayable yet) instead of wrapping the null in a `NonClearGraphics`/`NonClearGraphics2D` that would throw a NullPointerException later when used.