### PR TITLE
Use untracked allocation for static JAWT instances on Linux and macOS

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
@@ -16,6 +16,7 @@ import org.lwjgl.system.APIUtil.APIVersion;
 import org.lwjgl.system.Checks;
 import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.jawt.JAWT;
 import org.lwjgl.system.jawt.JAWTDrawingSurface;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
@@ -60,7 +61,7 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
     private long eglContext;
 
     private static JAWT createAWT() {
-        JAWT awt = JAWT.calloc();
+        JAWT awt = JAWT.create(MemoryUtil.getAllocator().calloc(1, JAWT.SIZEOF)); // untracked allocation
         awt.version(JAWT_VERSION_1_4);
         if (!JAWT_GetAWT(awt)) {
             throw new AssertionError("GetAWT failed");

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -33,6 +33,7 @@ import org.lwjgl.system.APIUtil;
 import org.lwjgl.system.Checks;
 import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.jawt.JAWT;
 import org.lwjgl.system.jawt.JAWTDrawingSurface;
 import org.lwjgl.system.jawt.JAWTDrawingSurfaceInfo;
@@ -47,7 +48,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	private static final long X_GET_GEOMETRY = X11.getLibrary().getFunctionAddress("XGetGeometry");
 	public static final JAWT awt;
 	static {
-		awt = JAWT.calloc();
+		awt = JAWT.create(MemoryUtil.getAllocator().calloc(1, JAWT.SIZEOF)); // untracked allocation
 		awt.version(JAWT_VERSION_1_4);
 		if (!JAWT_GetAWT(awt))
 			throw new AssertionError("GetAWT failed");

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -45,7 +45,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
     private static final long NSOpenGLPixelFormat;
 
     static {
-        awt = JAWT.calloc();
+        awt = JAWT.create(MemoryUtil.getAllocator().calloc(1, JAWT.SIZEOF)); // untracked allocation
         awt.version(JAWT_VERSION_1_7);
         if (!JAWT_GetAWT(awt))
             throw new AssertionError("GetAWT failed");


### PR DESCRIPTION
The static `JAWT` structs in `PlatformLinuxGLCanvas`, `PlatformLinuxEGLCanvas`, and `PlatformMacOSXGLCanvas` live for the whole process and are never freed, but they were allocated with the tracked `JAWT.calloc()`. This caused LWJGL's debug allocator to report them as memory leaks at shutdown.

This PR switches them to the same untracked allocation the Windows implementation already uses, so all platforms are consistent and the false leak reports go away. No functional change.