### PR TITLE
Validate GLX canvas attributes

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -73,9 +73,6 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	private Canvas canvas;
 
 	private long create(int depth, GLData attribs, GLData effective) throws AWTException {
-		if (attribs.versionPolicy != GLData.VersionPolicy.EXACT) {
-			GLUtil.validateVersionAttributes(attribs);
-		}
 		int screen = X11.XDefaultScreen(display);
 		Set<String> extensions = GLXSwapInterval.parseExtensions(
 				glXQueryExtensionsString(display, screen));
@@ -205,6 +202,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	}
 
 	public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
+		GLUtil.validateAttributes(attribs);
 		this.canvas = canvas;
 		JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
 		try {

--- a/test/org/lwjgl/opengl/awt/LinuxGLXCanvasIntegrationTest.java
+++ b/test/org/lwjgl/opengl/awt/LinuxGLXCanvasIntegrationTest.java
@@ -12,12 +12,67 @@ import java.awt.Dimension;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @EnabledOnOs(OS.LINUX)
 class LinuxGLXCanvasIntegrationTest {
+    @Test
+    void validatesFramebufferAndSwapAttributes() throws Exception {
+        assumeGLXIsSelected();
+
+        GLData data = new GLData();
+        data.depthSize = -1;
+
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+        AtomicReference<TestCanvas> canvasRef = new AtomicReference<>();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = new TestCanvas(data);
+                canvas.setPreferredSize(new Dimension(320, 240));
+
+                JFrame frame = new JFrame("Linux GLX attribute validation test");
+                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                frame.getContentPane().add(canvas);
+                frame.pack();
+                frame.setVisible(true);
+                frameRef.set(frame);
+                canvasRef.set(canvas);
+            });
+
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = canvasRef.get();
+                IllegalArgumentException negativeDepth = assertThrows(
+                        IllegalArgumentException.class, canvas::render);
+                assertTrue(negativeDepth.getMessage().contains("Depth bits"));
+
+                data.depthSize = 24;
+                data.samples = 1;
+                data.colorSamplesNV = 2;
+                IllegalArgumentException excessiveColorSamples = assertThrows(
+                        IllegalArgumentException.class, canvas::render);
+                assertTrue(excessiveColorSamples.getMessage().contains("Color samples greater"));
+
+                data.samples = 0;
+                data.colorSamplesNV = 0;
+                data.doubleBuffer = false;
+                data.swapInterval = 1;
+                IllegalArgumentException singleBufferedSwapInterval = assertThrows(
+                        IllegalArgumentException.class, canvas::render);
+                assertTrue(singleBufferedSwapInterval.getMessage().contains("Swap interval"));
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                JFrame frame = frameRef.get();
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
     @Test
     void selectsAnAtLeastCoreProfileContext() throws Exception {
         assumeGLXIsSelected();


### PR DESCRIPTION
The GLX backend skipped general attribute validation for the default `EXACT` policy, allowing invalid framebuffer and swap settings to reach native GLX calls. This change validates all attributes before creating the drawing surface and adds regression coverage for invalid settings.