### PR TITLE
Harden drawing surface lifecycle checks

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
@@ -56,6 +56,7 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
 
     private Canvas canvas;
     private JAWTDrawingSurface ds;
+    private Thread drawingSurfaceThread;
     private DisplayRef displayRef;
     private long eglDisplay;
     private long eglSurface;
@@ -477,6 +478,12 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
 
     @Override
     public void lock() throws AWTException {
+        if (ds != null) {
+            throw new AWTException("JAWT drawing surface is already locked");
+        }
+        if (canvas == null) {
+            throw new AWTException("Canvas has not been created or was disposed");
+        }
         JAWTDrawingSurface drawingSurface = JAWT_GetDrawingSurface(canvas, AWT.GetDrawingSurface());
         if (drawingSurface == null) {
             throw new AWTException("Failed to get JAWT drawing surface");
@@ -487,6 +494,7 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
             throw new AWTException("JAWT_DrawingSurface_Lock() failed");
         }
         ds = drawingSurface;
+        drawingSurfaceThread = Thread.currentThread();
     }
 
     @Override
@@ -495,16 +503,21 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
         if (drawingSurface == null) {
             throw new AWTException("JAWT drawing surface is not locked");
         }
+        if (drawingSurfaceThread != Thread.currentThread()) {
+            throw new AWTException("JAWT drawing surface must be unlocked by the thread that locked it");
+        }
+        ds = null;
+        drawingSurfaceThread = null;
         try {
             JAWT_DrawingSurface_Unlock(drawingSurface, drawingSurface.Unlock());
         } finally {
             JAWT_FreeDrawingSurface(drawingSurface, AWT.FreeDrawingSurface());
-            ds = null;
         }
     }
 
     @Override
     public boolean makeCurrent(long context) {
+        requireLockedDrawingSurface();
         if (eglDisplay == EGL_NO_DISPLAY) {
             return context == EGL_NO_CONTEXT;
         }
@@ -512,6 +525,15 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
             return eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
         }
         return eglMakeCurrent(eglDisplay, eglSurface, eglSurface, context);
+    }
+
+    private void requireLockedDrawingSurface() {
+        if (ds == null) {
+            throw new IllegalStateException("The JAWT drawing surface must be locked for this operation");
+        }
+        if (drawingSurfaceThread != Thread.currentThread()) {
+            throw new IllegalStateException("JAWT drawing surface is locked by another thread");
+        }
     }
 
     @Override

--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -71,6 +71,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	public long drawable;
 	public JAWTDrawingSurface ds;
 	private Canvas canvas;
+	private Thread drawingSurfaceThread;
 
 	private long create(int depth, GLData attribs, GLData effective) throws AWTException {
 		if (attribs.versionPolicy != GLData.VersionPolicy.EXACT) {
@@ -133,7 +134,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 		try {
 			populateEffectiveGLXAttribs(display, fbConfigs.get(0), effective);
 
-			if (!makeCurrent(context)) {
+			if (!glXMakeCurrent(display, drawable, context)) {
 				throw new AWTException("Unable to make context current");
 			}
 			// Mesa resolves an implicit GLX drawable while binding it, so configure the
@@ -146,7 +147,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 			initialized = true;
 			return context;
 		} finally {
-			makeCurrent(0 /* no context */);
+			glXMakeCurrent(display, 0L, 0L);
 			if (!initialized) {
 				glXDestroyContext(display, context);
 			}
@@ -179,6 +180,12 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	}
 
 	public void lock() throws AWTException {
+		if (ds != null) {
+			throw new AWTException("JAWT drawing surface is already locked");
+		}
+		if (canvas == null) {
+			throw new AWTException("Canvas has not been created or was disposed");
+		}
 		JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
 		if (ds == null) {
 			throw new AWTException("Failed to get JAWT drawing surface");
@@ -189,6 +196,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 			throw new AWTException("JAWT_DrawingSurface_Lock() failed");
 		}
 		this.ds = ds;
+		this.drawingSurfaceThread = Thread.currentThread();
 	}
 
 	public void unlock() throws AWTException {
@@ -196,23 +204,33 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 		if (ds == null) {
 			throw new AWTException("JAWT drawing surface is not locked");
 		}
+		if (drawingSurfaceThread != Thread.currentThread()) {
+			throw new AWTException("JAWT drawing surface must be unlocked by the thread that locked it");
+		}
+		this.ds = null;
+		this.drawingSurfaceThread = null;
 		try {
 			JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
 		} finally {
 			JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
-			this.ds = null;
 		}
 	}
 
 	public long create(Canvas canvas, GLData attribs, GLData effective) throws AWTException {
 		this.canvas = canvas;
 		JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
+		if (ds == null) {
+			throw new AWTException("Failed to get JAWT drawing surface");
+		}
 		try {
 			int lock = JAWT_DrawingSurface_Lock(ds, ds.Lock());
 			if ((lock & JAWT_LOCK_ERROR) != 0)
 				throw new AWTException("JAWT_DrawingSurface_Lock() failed");
 			try {
 				JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds, ds.GetDrawingSurfaceInfo());
+				if (dsi == null) {
+					throw new AWTException("Failed to get JAWT drawing surface information");
+				}
 				try {
 					JAWTX11DrawingSurfaceInfo dsiWin = JAWTX11DrawingSurfaceInfo.create(dsi.platformInfo());
 					int depth = dsiWin.depth();
@@ -236,9 +254,19 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 	}
 
 	public boolean makeCurrent(long context) {
+		requireLockedDrawingSurface();
 		if (context == 0L)
 			return glXMakeCurrent(display, 0L, 0L);
 		return glXMakeCurrent(display, drawable, context);
+	}
+
+	private void requireLockedDrawingSurface() {
+		if (ds == null) {
+			throw new IllegalStateException("The JAWT drawing surface must be locked for this operation");
+		}
+		if (drawingSurfaceThread != Thread.currentThread()) {
+			throw new IllegalStateException("JAWT drawing surface is locked by another thread");
+		}
 	}
 
 	public boolean isCurrent(long context) {

--- a/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformMacOSXGLCanvas.java
@@ -57,6 +57,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     public JAWTDrawingSurface ds;
     private Canvas canvas;
+    private Thread drawingSurfaceThread;
     private long view;
     private long interLayer;
     private long surfaceLayer;
@@ -610,6 +611,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     @Override
     public boolean makeCurrent(long context) {
+        requireLockedDrawingSurface();
         if (CGLSetCurrentContext(context) != kCGLNoError) {
             return false;
         }
@@ -643,6 +645,15 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
             }
         }
         return true;
+    }
+
+    private void requireLockedDrawingSurface() {
+        if (ds == null) {
+            throw new IllegalStateException("The JAWT drawing surface must be locked for this operation");
+        }
+        if (drawingSurfaceThread != Thread.currentThread()) {
+            throw new IllegalStateException("JAWT drawing surface is locked by another thread");
+        }
     }
 
     private void updateLayerBounds(int[] bounds) {
@@ -713,6 +724,12 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
 
     @Override
     public void lock() throws AWTException {
+        if (ds != null) {
+            throw new AWTException("JAWT drawing surface is already locked");
+        }
+        if (canvas == null) {
+            throw new AWTException("Canvas has not been created or was disposed");
+        }
         JAWTDrawingSurface ds = JAWT_GetDrawingSurface(canvas, awt.GetDrawingSurface());
         if (ds == null) {
             throw new AWTException("Failed to get JAWT drawing surface");
@@ -723,6 +740,7 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
             throw new AWTException("JAWT_DrawingSurface_Lock() failed");
         }
         this.ds = ds;
+        this.drawingSurfaceThread = Thread.currentThread();
     }
 
     @Override
@@ -731,11 +749,15 @@ public class PlatformMacOSXGLCanvas implements PlatformGLCanvas {
         if (ds == null) {
             throw new AWTException("JAWT drawing surface is not locked");
         }
+        if (drawingSurfaceThread != Thread.currentThread()) {
+            throw new AWTException("JAWT drawing surface must be unlocked by the thread that locked it");
+        }
+        this.ds = null;
+        this.drawingSurfaceThread = null;
         try {
             JAWT_DrawingSurface_Unlock(ds, ds.Unlock());
         } finally {
             JAWT_FreeDrawingSurface(ds, awt.FreeDrawingSurface());
-            this.ds = null;
         }
     }
 

--- a/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLCanvasLifecycleTest.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 
 import static java.nio.ByteOrder.nativeOrder;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -120,6 +121,32 @@ class MacOSXGLCanvasLifecycleTest {
             assertTrue(canvas.surfaceBackingSizeEnabled);
             assertEquals(canvas.getFramebufferWidth(), canvas.surfaceBackingWidth);
             assertEquals(canvas.getFramebufferHeight(), canvas.surfaceBackingHeight);
+        } finally {
+            SwingUtilities.invokeAndWait(state.frame::dispose);
+        }
+    }
+
+    @Test
+    void rejectsDrawingSurfaceLifecycleMisuse() throws Exception {
+        FrameState state = showSingleCanvas();
+        try {
+            renderCanvases(state);
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = state.canvases[0];
+                PlatformMacOSXGLCanvas platform = (PlatformMacOSXGLCanvas) canvas.platformCanvas;
+
+                IllegalStateException unlocked = assertThrows(
+                        IllegalStateException.class, () -> platform.makeCurrent(canvas.context));
+                assertTrue(unlocked.getMessage().contains("must be locked"));
+
+                assertDoesNotThrow(platform::lock);
+                try {
+                    AWTException nested = assertThrows(AWTException.class, platform::lock);
+                    assertTrue(nested.getMessage().contains("already locked"));
+                } finally {
+                    assertDoesNotThrow(platform::unlock);
+                }
+            });
         } finally {
             SwingUtilities.invokeAndWait(state.frame::dispose);
         }


### PR DESCRIPTION
Win32 already tracks which thread locked the JAWT drawing surface, but GLX, EGL, and macOS did not. Since drawing-surface locks and context operations must stay on the owning thread, this change applies the same ownership checks to those backends, rejects nested locks, and adds missing GLX null checks.