### PR TITLE
Honor HIGHEST version policy on macOS

### DIFF
--- a/src/org/lwjgl/opengl/awt/MacOSXGLDataUtil.java
+++ b/src/org/lwjgl/opengl/awt/MacOSXGLDataUtil.java
@@ -55,7 +55,8 @@ final class MacOSXGLDataUtil {
         if (data.profile == GLData.Profile.COMPATIBILITY) {
             throw new AWTException("macOS NSOpenGL does not support compatibility profiles newer than OpenGL 2.1");
         }
-        if (data.majorVersion > 4 || (data.majorVersion == 4 && data.minorVersion > 1)) {
+        if (data.versionPolicy != GLData.VersionPolicy.HIGHEST
+                && (data.majorVersion > 4 || (data.majorVersion == 4 && data.minorVersion > 1))) {
             throw new AWTException("macOS NSOpenGL supports OpenGL versions up to 4.1");
         }
     }

--- a/test/org/lwjgl/opengl/awt/MacOSXGLDataUtilTest.java
+++ b/test/org/lwjgl/opengl/awt/MacOSXGLDataUtilTest.java
@@ -144,6 +144,23 @@ class MacOSXGLDataUtilTest {
     }
 
     @Test
+    void highestIgnoresConfiguredVersionAboveMacOSMaximum() throws Exception {
+        GLData data = new GLData();
+        data.majorVersion = 4;
+        data.minorVersion = 6;
+        data.profile = GLData.Profile.CORE;
+        data.versionPolicy = GLData.VersionPolicy.HIGHEST;
+
+        MacOSXGLDataUtil.validateAttributes(data);
+        MacOSXGLDataUtil.PixelFormatSelection selection = MacOSXGLDataUtil.choosePixelFormat(
+                data, attributes -> 42L);
+
+        assertEquals(42L, selection.pixelFormat);
+        assertTrue(containsPair(selection.attributes,
+                NS_OPENGL_PFA_OPENGL_PROFILE, NS_OPENGL_PROFILE_4_1_CORE));
+    }
+
+    @Test
     void rejectsOptionsThatNSOpenGLCannotHonor() {
         assertUnsupported(data -> data.api = GLData.API.GLES, "OpenGL ES");
         assertUnsupported(data -> data.debug = true, "debug");


### PR DESCRIPTION
The macOS backend rejected configured versions above OpenGL 4.1 even with the `HIGHEST` policy, which is supposed to ignore the configured version. This change skips that validation for HIGHEST while continuing to select at most the platform-supported OpenGL 4.1 profile.