### PR TITLE
Preserve shared EGL display initialization

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxEGLCanvas.java
@@ -622,9 +622,6 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
             DisplayRef created = new DisplayRef(eglDisplay, capabilities);
             DISPLAY_REFS.put(eglDisplay, created);
             return created;
-        } catch (AWTException | RuntimeException | Error failure) {
-            eglTerminate(eglDisplay);
-            throw failure;
         }
     }
 
@@ -650,7 +647,9 @@ public class PlatformLinuxEGLCanvas implements PlatformGLCanvas {
     private static synchronized void releaseDisplay(DisplayRef ref) {
         if (--ref.references == 0) {
             DISPLAY_REFS.remove(ref.eglDisplay);
-            eglTerminate(ref.eglDisplay);
+            // EGLDisplay initialization is process-wide rather than reference-counted. Calling eglTerminate here
+            // would invalidate contexts and surfaces owned by another toolkit that uses the same native display.
+            // Leave termination to process teardown; removing our Java-side entry still releases its capabilities.
         }
     }
 

--- a/test/org/lwjgl/opengl/awt/LinuxEGLCanvasIntegrationTest.java
+++ b/test/org/lwjgl/opengl/awt/LinuxEGLCanvasIntegrationTest.java
@@ -12,9 +12,15 @@ import java.awt.Dimension;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.lwjgl.egl.EGL10.EGL_NO_CONTEXT;
+import static org.lwjgl.egl.EGL10.EGL_NO_DISPLAY;
+import static org.lwjgl.egl.EGL10.EGL_VERSION;
+import static org.lwjgl.egl.EGL10.eglQueryString;
+import static org.lwjgl.egl.EGL14.eglGetCurrentDisplay;
 import static org.lwjgl.egl.EGL14.eglGetCurrentContext;
 
 @EnabledOnOs(OS.LINUX)
@@ -70,6 +76,35 @@ class LinuxEGLCanvasIntegrationTest {
                 GL.setCapabilities(null);
                 dispose(firstFrameRef.get());
                 dispose(secondFrameRef.get());
+            });
+        }
+    }
+
+    @Test
+    void leavesTheSharedDisplayInitializedAfterTheLastCanvasIsDisposed() throws Exception {
+        assumeEGLIsSelected();
+
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+        AtomicReference<TestCanvas> canvasRef = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() ->
+                createFrame("Shared Linux EGL display", frameRef, canvasRef));
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                TestCanvas canvas = canvasRef.get();
+                canvas.render();
+                long display = canvas.lastCurrentDisplay;
+                assertNotEquals(EGL_NO_DISPLAY, display);
+
+                GL.setCapabilities(null);
+                frameRef.get().dispose();
+
+                assertNotNull(eglQueryString(display, EGL_VERSION));
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                GL.setCapabilities(null);
+                dispose(frameRef.get());
             });
         }
     }
@@ -143,6 +178,7 @@ class LinuxEGLCanvasIntegrationTest {
 
     private static final class TestCanvas extends AWTGLCanvas {
         private static final long serialVersionUID = 1L;
+        private long lastCurrentDisplay = EGL_NO_DISPLAY;
 
         private TestCanvas() {
         }
@@ -160,6 +196,7 @@ class LinuxEGLCanvasIntegrationTest {
         public void paintGL() {
             assertTrue(context != EGL_NO_CONTEXT);
             assertEquals(context, eglGetCurrentContext());
+            lastCurrentDisplay = eglGetCurrentDisplay();
             swapBuffers();
         }
     }


### PR DESCRIPTION
The EGL backend called `eglTerminate` when its internal reference count reached zero. EGL displays can be shared with other libraries, so this could invalidate resources belonging to GLFW, JavaFX, or another toolkit. This change releases the backend’s Java-side references without terminating the shared display.