### PR TITLE
Reject invalid buffer swaps

### DIFF
--- a/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/AWTGLCanvas.java
@@ -439,6 +439,15 @@ public abstract class AWTGLCanvas extends Canvas {
     public final void swapBuffers() {
         lifecycleLock.lock();
         try {
+            if (disposing) {
+                throw new IllegalStateException("Canvas is being disposed");
+            }
+            if (context == 0L) {
+                throw new IllegalStateException("OpenGL context has not been created or was disposed");
+            }
+            if (!platformCanvas.isCurrent(context)) {
+                throw new IllegalStateException("OpenGL context must be current before swapping buffers");
+            }
             platformCanvas.swapBuffers();
         } finally {
             lifecycleLock.unlock();

--- a/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
+++ b/test/org/lwjgl/opengl/awt/AWTGLCanvasLifecycleTest.java
@@ -432,6 +432,51 @@ class AWTGLCanvasLifecycleTest {
     }
 
     @Test
+    void swapBuffersRejectsCallsAfterContextDisposal() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        TestCanvas canvas = new TestCanvas(platform);
+        canvas.context = 42L;
+        canvas.disposeCanvas();
+        platform.calls.clear();
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::swapBuffers);
+
+        assertEquals("OpenGL context has not been created or was disposed", failure.getMessage());
+        assertTrue(platform.calls.isEmpty());
+    }
+
+    @Test
+    void swapBuffersRejectsCallsDuringContextDisposal() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        AtomicReference<IllegalStateException> failureRef = new AtomicReference<>();
+        TestCanvas canvas = new TestCanvas(platform) {
+            @Override
+            protected void disposeGL() {
+                failureRef.set(assertThrows(IllegalStateException.class, this::swapBuffers));
+            }
+        };
+        canvas.context = 42L;
+
+        canvas.disposeCanvas();
+
+        assertEquals("Canvas is being disposed", failureRef.get().getMessage());
+        assertFalse(platform.calls.contains("swapBuffers"));
+    }
+
+    @Test
+    void swapBuffersRejectsCallsWhenTheCanvasContextIsNotCurrent() {
+        RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
+        TestCanvas canvas = new TestCanvas(platform);
+        canvas.render();
+        platform.calls.clear();
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, canvas::swapBuffers);
+
+        assertEquals("OpenGL context must be current before swapping buffers", failure.getMessage());
+        assertTrue(platform.calls.isEmpty());
+    }
+
+    @Test
     void renderUnlocksDrawingSurfaceWhenPaintingFails() {
         RecordingPlatformCanvas platform = new RecordingPlatformCanvas();
         TestCanvas canvas = new TestCanvas(platform) {


### PR DESCRIPTION
`swapBuffers()` previously entered the native backend without checking the canvas lifecycle or current context. This change rejects calls during disposal, after context deletion, or when the canvas context is not current.