### PR TITLE
Free GLX framebuffer config arrays

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -94,9 +94,17 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 		attrib_list.put(0);
 		attrib_list.flip();
 		PointerBuffer fbConfigs = glXChooseFBConfig(display, screen, attrib_list);
-		if (fbConfigs == null || fbConfigs.capacity() == 0) {
-			// No framebuffer configurations supported!
-			throw new AWTException("No supported framebuffer configurations found");
+		long fbConfig;
+		try {
+			if (fbConfigs == null || fbConfigs.capacity() == 0) {
+				// No framebuffer configurations supported!
+				throw new AWTException("No supported framebuffer configurations found");
+			}
+			fbConfig = fbConfigs.get(0);
+		} finally {
+			if (fbConfigs != null) {
+				X11.XFree(fbConfigs);
+			}
 		}
 
 		GLXSwapInterval swapInterval = verifyGLXCapabilities(extensions, attribs);
@@ -115,7 +123,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 		
 		long context = 0L;
 		for (GLUtil.ContextVersion version : candidates) {
-			context = tryCreateContext(fbConfigs.get(0), share_context,
+			context = tryCreateContext(fbConfig, share_context,
 					bufferGLAttribs(attribs, version));
 			if (context != 0L) {
 				break;
@@ -131,7 +139,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 
 		boolean initialized = false;
 		try {
-			populateEffectiveGLXAttribs(display, fbConfigs.get(0), effective);
+			populateEffectiveGLXAttribs(display, fbConfig, effective);
 
 			if (!makeCurrent(context)) {
 				throw new AWTException("Unable to make context current");


### PR DESCRIPTION
`glXChooseFBConfig` returns an Xlib-allocated array that must be released with `XFree`. The backend retained the selected handle but never freed the array. This change copies the handle and releases the array immediately.