### PR TITLE
Guard GLX profile mask queries

### DIFF
--- a/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
+++ b/src/org/lwjgl/opengl/awt/PlatformLinuxGLCanvas.java
@@ -148,7 +148,7 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 				swapInterval.apply(display, drawable);
 			}
 			effective.versionPolicy = attribs.versionPolicy;
-			populateEffectiveGLAttribs(effective);
+			populateEffectiveGLAttribs(attribs, effective);
 			initialized = true;
 			return context;
 		} finally {
@@ -468,37 +468,27 @@ public class PlatformLinuxGLCanvas implements PlatformGLCanvas {
 		effective.doubleBuffer = buffer.get(0) == 1;
 	}
 
-	private static void populateEffectiveGLAttribs(GLData effective) throws AWTException {
+	private static void populateEffectiveGLAttribs(GLData requested, GLData effective) throws AWTException {
 		long glGetIntegerv = GL.getFunctionProvider().getFunctionAddress("glGetIntegerv");
 		long glGetString = GL.getFunctionProvider().getFunctionAddress("glGetString");
 		APIVersion version = APIUtil.apiParseVersion(getString(GL11.GL_VERSION, glGetString));
 
+		effective.api = requested.api;
 		effective.majorVersion = version.major;
 		effective.minorVersion = version.minor;
 
-		int profileFlags = getInteger(GL32.GL_CONTEXT_PROFILE_MASK, glGetIntegerv);
-
-		if ((profileFlags & GLX_CONTEXT_ES_PROFILE_BIT_EXT) != 0) {
-			effective.api = GLData.API.GLES;
-		} else {
-			effective.api = GLData.API.GL;
+		if (requested.api == GLData.API.GL && GLUtil.atLeast32(version.major, version.minor)) {
+			int profileFlags = getInteger(GL32.GL_CONTEXT_PROFILE_MASK, glGetIntegerv);
+			if ((profileFlags & GL32.GL_CONTEXT_CORE_PROFILE_BIT) != 0) {
+				effective.profile = GLData.Profile.CORE;
+			} else if ((profileFlags & GL32.GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) != 0) {
+				effective.profile = GLData.Profile.COMPATIBILITY;
+			} else if (profileFlags != 0) {
+				throw new AWTException("Unknown profile " + profileFlags);
+			}
 		}
 
 		if (version.major >= 3) {
-			if (version.major >= 4 || version.minor >= 2) {
-				if ((profileFlags & GL32.GL_CONTEXT_CORE_PROFILE_BIT) != 0) {
-					effective.profile = GLData.Profile.CORE;
-				} else if ((profileFlags & GL32.GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) != 0) {
-					effective.profile = GLData.Profile.COMPATIBILITY;
-				} else if (
-						(profileFlags & GLX_CONTEXT_ES_PROFILE_BIT_EXT) != 0) {
-					// OpenGL ES allows checking for profiles at versions below 3.2, so avoid branching into
-					// the if and actually check later.
-				} else if (profileFlags != 0) {
-					throw new AWTException("Unknown profile " + profileFlags);
-				}
-			}
-
 			int effectiveContextFlags = getInteger(GL30.GL_CONTEXT_FLAGS, glGetIntegerv);
 			effective.debug = (effectiveContextFlags & GL43.GL_CONTEXT_FLAG_DEBUG_BIT) != 0;
 			effective.forwardCompatible =

--- a/test/org/lwjgl/opengl/awt/LinuxGLXCanvasIntegrationTest.java
+++ b/test/org/lwjgl/opengl/awt/LinuxGLXCanvasIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.lwjgl.opengl.GL;
 import org.lwjgl.system.Configuration;
+import org.lwjgl.system.JNI;
 
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -16,9 +17,52 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.lwjgl.opengl.GL11.GL_NO_ERROR;
 
 @EnabledOnOs(OS.LINUX)
 class LinuxGLXCanvasIntegrationTest {
+    @Test
+    void leavesOpenGL31ContextErrorStateClean() throws Exception {
+        assumeGLXIsSelected();
+
+        GLData data = new GLData();
+        data.majorVersion = 3;
+        data.minorVersion = 1;
+
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+        AtomicReference<ErrorCheckingCanvas> canvasRef = new AtomicReference<>();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                ErrorCheckingCanvas canvas = new ErrorCheckingCanvas(data);
+                canvas.setPreferredSize(new Dimension(320, 240));
+
+                JFrame frame = new JFrame("Linux GLX 3.1 context query test");
+                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                frame.getContentPane().add(canvas);
+                frame.pack();
+                frame.setVisible(true);
+                frameRef.set(frame);
+                canvasRef.set(canvas);
+            });
+
+            SwingUtilities.invokeAndWait(() -> canvasRef.get().render());
+
+            ErrorCheckingCanvas canvas = canvasRef.get();
+            assumeTrue(canvas.effective.majorVersion == 3 && canvas.effective.minorVersion == 1,
+                    "The GLX implementation returned OpenGL "
+                            + canvas.effective.majorVersion + "." + canvas.effective.minorVersion);
+            assertEquals(GL_NO_ERROR, canvas.errorBeforeCapabilities);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                GL.setCapabilities(null);
+                JFrame frame = frameRef.get();
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
     @Test
     void validatesFramebufferAndSwapAttributes() throws Exception {
         assumeGLXIsSelected();
@@ -196,6 +240,28 @@ class LinuxGLXCanvasIntegrationTest {
 
         @Override
         public void initGL() {
+            GL.createCapabilities();
+        }
+
+        @Override
+        public void paintGL() {
+            swapBuffers();
+        }
+    }
+
+    private static final class ErrorCheckingCanvas extends AWTGLCanvas {
+        private static final long serialVersionUID = 1L;
+
+        private int errorBeforeCapabilities;
+
+        private ErrorCheckingCanvas(GLData data) {
+            super(data);
+        }
+
+        @Override
+        public void initGL() {
+            long glGetError = GL.getFunctionProvider().getFunctionAddress("glGetError");
+            errorBeforeCapabilities = JNI.callI(glGetError);
             GL.createCapabilities();
         }
 


### PR DESCRIPTION
`GL_CONTEXT_PROFILE_MASK` is only valid for desktop OpenGL 3.2+. This PR guards the native GLX query accordingly and preserves the requested API directly.